### PR TITLE
Add SHAREXP distinction, create UNKNOWNXP default

### DIFF
--- a/doc/mapserver-logging
+++ b/doc/mapserver-logging
@@ -5,6 +5,7 @@ LOGLINE ::= int'.'int <MESSAGE>
 MESSAGE ::= 'log-start'
           | 'log-start v2'
           | 'log-start v3'
+          | 'log-start v4'
           | <PC> <COORD> <PC-MESSAGE>
           | <MOB> <MOB-MESSAGE>
 
@@ -22,14 +23,14 @@ STATPLACE ::= 'LOGIN' | 'STATUP' | 'STATUP2' | 'STATRESET'
 
 XPPLACE ::= 'LOGIN' | 'LEVELUP'
 
-XPREASON ::= 'SCRIPTXP' 'HEALXP' 'KILLXP'
+XPREASON ::= 'SCRIPTXP' | 'HEALXP' | 'KILLXP' | 'SHAREXP' | 'UNKNOWNXP'
 
 ZEROTARGET ::= 'null' | <TARGET>
 
 MOB-MESSAGE ::= 'DEAD'
 
 PC-MESSAGE ::= 'WPNDMG' <TARGET> int 'FOR' int WPN int				# "WPNDMG MOB01 type FOR damage WPN weapon-item" 
-	     | 'WPNINJURY' <TARGET> int 'FOR' int
+             | 'WPNINJURY' <TARGET> int 'FOR' int
              | 'MOB-TO-MOB-DMG' 'FROM' <MOB> int 'TO' <MOB> int 'FOR' int	# Summoned monster damage
              | 'SPELLHEAL-INSTA' <PC> FOR int
              | 'SPELLDMG' <MOB> FOR int BY spell-id
@@ -52,7 +53,7 @@ PC-MESSAGE ::= 'WPNDMG' <TARGET> int 'FOR' int WPN int				# "WPNDMG MOB01 type F
              | 'TRADEOK'
              | 'STATUP'
              | 'STATRESET'
-             | 'STATUP'
+             | 'STATUP2'
 
 NOTES:
 ------

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1562,7 +1562,7 @@ void map_set_logfile(const char *filename)
 
     map_start_logfile(tv.tv_sec);
 
-    MAP_LOG("log-start v3");
+    MAP_LOG("log-start v4");
 }
 
 void map_log(const_string line)

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -2616,7 +2616,8 @@ int mob_damage(struct block_list *src, struct mob_data *md, int damage,
                 }
             }
             if (flag)           // 各自所得
-                pc_gainexp(tmpsd[i], base_exp, job_exp);
+                pc_gainexp_reason(tmpsd[i], base_exp, job_exp,
+                                  PC_GAINEXP_REASON::KILLING);
         }
         // 公平分配
         for (int i = 0; i < pnum; i++)

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -717,7 +717,8 @@ int party_exp_share(struct party *p, int mapid, int base_exp, int job_exp)
         return 0;
     for (i = 0; i < MAX_PARTY; i++)
         if ((sd = p->member[i].sd) != NULL && sd->bl.m == mapid)
-            pc_gainexp(sd, base_exp / c + 1, job_exp / c + 1);
+            pc_gainexp_reason(sd, base_exp / c + 1, job_exp / c + 1,
+            PC_GAINEXP_REASON::SHARING);
     return 0;
 }
 

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -3114,7 +3114,7 @@ int pc_checkjoblevelup(struct map_session_data *sd)
 int pc_gainexp(struct map_session_data *sd, int base_exp, int job_exp)
 {
     return pc_gainexp_reason(sd, base_exp, job_exp,
-                              PC_GAINEXP_REASON::KILLING);
+                              PC_GAINEXP_REASON::UNKNOWN);
 }
 
 int pc_gainexp_reason(struct map_session_data *sd, int base_exp, int job_exp,
@@ -3133,6 +3133,9 @@ int pc_gainexp_reason(struct map_session_data *sd, int base_exp, int job_exp,
         "KILLXP",
         "HEALXP",
         "SCRIPTXP",
+        "SHAREXP",
+        /* Insert new types here */
+        "UNKNOWNXP"
     }};
     MAP_LOG_PC(sd, "GAINXP %d %d %s", base_exp, job_exp, reasons[reason]);
 

--- a/src/map/pc.t.hpp
+++ b/src/map/pc.t.hpp
@@ -8,7 +8,9 @@ enum class PC_GAINEXP_REASON
     KILLING = 0,
     HEALING = 1,
     SCRIPT  = 2,
+    SHARING = 3,
 
+    UNKNOWN,
     COUNT,
 };
 


### PR DESCRIPTION
Previously, KILLXP was being set as the catchall, which caused false
positives for XP sharing.

Update documentation accordingly.

log version incremented to 4.
