### PR TITLE
Local Spawn Point per Map override

### DIFF
--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -1041,8 +1041,16 @@ ATCE atcommand_load(const int fd, dumb_ptr<map_session_data> sd,
         return ATCE::PERM;
     }
 
-    pc_setpos(sd, sd->status.save_point.map_, sd->status.save_point.x,
-               sd->status.save_point.y, BeingRemoveWhy::GONE);
+    if (sd->bl_m->flag.resave)
+    {
+        pc_setpos(sd, sd->bl_m->resave.map_, sd->bl_m->resave.x,
+                   sd->bl_m->resave.y, BeingRemoveWhy::GONE);
+    }
+    else
+    {
+        pc_setpos(sd, sd->status.save_point.map_, sd->status.save_point.x,
+                   sd->status.save_point.y, BeingRemoveWhy::GONE);
+    }
     clif_displaymessage(fd, "Warping to respawn point.");
 
     return ATCE::OKAY;
@@ -3488,6 +3496,9 @@ ATCE atcommand_mapinfo(const int fd, dumb_ptr<map_session_data> sd,
     clif_displaymessage(fd, output);
     output = STRPRINTF("No Save: %s",
              (m_id->flag.nosave) ? "True" : "False");
+    clif_displaymessage(fd, output);
+    output = STRPRINTF("Re Save: %s",
+             (m_id->flag.resave) ? "True" : "False");
     clif_displaymessage(fd, output);
     output = STRPRINTF("No Teleport: %s",
              (m_id->flag.noteleport) ? "True" : "False");

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -4014,9 +4014,18 @@ void clif_parse_Restart(int fd, dumb_ptr<map_session_data> sd)
             {
                 pc_setstand(sd);
                 pc_setrestartvalue(sd, 3);
-                pc_setpos(sd, sd->status.save_point.map_,
-                           sd->status.save_point.x, sd->status.save_point.y,
-                           BeingRemoveWhy::QUIT);
+                if (sd->bl_m->flag.resave)
+                {
+                    pc_setpos(sd, sd->bl_m->resave.map_,
+                               sd->bl_m->resave.x, sd->bl_m->resave.y,
+                               BeingRemoveWhy::QUIT);
+                }
+                else
+                {
+                    pc_setpos(sd, sd->status.save_point.map_,
+                               sd->status.save_point.x, sd->status.save_point.y,
+                               BeingRemoveWhy::QUIT);
+                }
             }
             break;
         case 0x01:

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -520,6 +520,7 @@ struct map_local : map_abstract
         unsigned noreturn:1;
         unsigned monster_noteleport:1;
         unsigned nosave:1;
+        unsigned resave:1;
         unsigned nobranch:1;
         unsigned nopenalty:1;
         unsigned pvp:1;
@@ -540,6 +541,7 @@ struct map_local : map_abstract
         unsigned town:1;        // [remoitnane]
     } flag;
     struct point save;
+    struct point resave;
     dumb_ptr<npc_data> npc[MAX_NPC_PER_MAP];
     struct
     {

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -1542,6 +1542,16 @@ int npc_parse_mapflag(XString w1, XString, XString w3, ZString w4)
         }
         m->flag.nosave = 1;
     }
+    else if (w3 == "resave")
+    {
+        if (extract(w4, record<','>(&savemap, &savex, &savey)))
+        {
+            m->resave.map_ = savemap;
+            m->resave.x = savex;
+            m->resave.y = savey;
+        }
+        m->flag.resave = 1;
+    }
     else if (w3 == "nomemo")
     {
         m->flag.nomemo = 1;

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -412,7 +412,14 @@ void pc_makesavestatus(dumb_ptr<map_session_data> sd)
     if (pc_isdead(sd))
     {
         pc_setrestartvalue(sd, 0);
-        sd->status.last_point = sd->status.save_point;
+        if (sd->bl_m->flag.resave)
+        {
+            sd->status.last_point = sd->bl_m->resave;
+        }
+        else
+        {
+            sd->status.last_point = sd->status.save_point;
+        }
     }
     else
     {

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -3161,6 +3161,7 @@ enum
     MF_SAKURA = 18,
     MF_LEAVES = 19,
     MF_RAIN = 20,
+    MF_RESAVE = 21,
 };
 
 static
@@ -3242,6 +3243,9 @@ void builtin_removemapflag(ScriptState *st)
             case MF_NOSAVE:
                 m->flag.nosave = 0;
                 break;
+            case MF_RESAVE:
+                m->flag.resave = 0;
+                break;
             case MF_NOBRANCH:
                 m->flag.nobranch = 0;
                 break;
@@ -3302,6 +3306,9 @@ void builtin_getmapflag(ScriptState *st)
                 break;
             case MF_NOSAVE:
                 r = m->flag.nosave;
+                break;
+            case MF_RESAVE:
+                r = m->flag.resave;
                 break;
             case MF_NOBRANCH:
                 r = m->flag.nobranch;


### PR DESCRIPTION
Mapflag: Resave
<map>.gat|mapflag|resave|<map>,<X>,<Y>
Spawns player at Map,X,Y rather than savepoint
Once off map, savepoint is respected again.
