### PR TITLE
add support for manaplus emotes

### DIFF
--- a/src/map/script-fun.cpp
+++ b/src/map/script-fun.cpp
@@ -2184,7 +2184,7 @@ static
 void builtin_emotion(ScriptState *st)
 {
     int type;
-    type = conv_num(st, &AARG(0)) + 1;
+    type = conv_num(st, &AARG(0));
     if (type < 0 || type > 200)
         return;
     clif_emotion(map_id2bl(st->oid), type);

--- a/src/map/script-fun.cpp
+++ b/src/map/script-fun.cpp
@@ -2184,8 +2184,8 @@ static
 void builtin_emotion(ScriptState *st)
 {
     int type;
-    type = conv_num(st, &AARG(0));
-    if (type < 0 || type > 100)
+    type = conv_num(st, &AARG(0)) + 1;
+    if (type < 0 || type > 200)
         return;
     clif_emotion(map_id2bl(st->oid), type);
 }


### PR DESCRIPTION
ManaPlus uses emotes above 100: https://github.com/ManaPlus/ManaPlus/blob/master/data/graphics/sprites/manaplus_emotes.xml

It was the case since at least 2011 but hasn't been fixed yet.
This PR allows npcs to use the full set of emotes.

- - -
sorry for the previous PR, was on master