### PR TITLE
Send spam messages to General tab

### DIFF
--- a/src/map/tmw.cpp
+++ b/src/map/tmw.cpp
@@ -109,8 +109,8 @@ int tmw_CheckChatSpam(dumb_ptr<map_session_data> sd, XString message)
         (sd->chat_lines_in >= battle_config.chat_spam_warn
          || sd->chat_total_repeats >= battle_config.chat_spam_warn))
     {
-        clif_displaymessage(sd->sess, "WARNING: You are about to be automatically banned for spam!"_s);
-        clif_displaymessage(sd->sess, "WARNING: Please slow down, do not repeat, and do not SHOUT!"_s);
+        clif_displaymessage(sd->sess, "##1WARNING : ##BYou are about to be automatically banned for spam!"_s);
+        clif_displaymessage(sd->sess, "##1WARNING : ##BPlease slow down, do not repeat, and do not SHOUT!"_s);
     }
 
     return 0;


### PR DESCRIPTION
I was puzzled to see that such an important message was silently sent to the Debug tab.
This PR makes the message go to the General tab and appear in bold red