### PR TITLE
remove deprecated cmdothernpc

### DIFF
--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -482,27 +482,6 @@ int npc_event(dumb_ptr<map_session_data> sd, NpcEvent eventname,
     return 0;
 }
 
-static
-void npc_command_sub(NpcEvent key, struct event_data *ev, NpcName npcname, XString command)
-{
-    if (ev->nd->name == npcname
-        && key.label.startswith("OnCommand"_s))
-    {
-        XString temp = key.label.xslice_t(9);
-
-        if (command == temp)
-            run_script(ScriptPointer(borrow(*ev->nd->scr.script), ev->pos), BlockId(), ev->nd->bl_id);
-    }
-}
-
-int npc_command(dumb_ptr<map_session_data>, NpcName npcname, XString command)
-{
-    for (auto& pair : ev_db)
-        npc_command_sub(pair.first, &pair.second, npcname, command);
-
-    return 0;
-}
-
 /*==========================================
  * 接触型のNPC処理
  *------------------------------------------

--- a/src/map/npc.hpp
+++ b/src/map/npc.hpp
@@ -46,7 +46,6 @@ constexpr Species INVISIBLE_CLASS = wrap<Species>(32767);
 
 int npc_event_dequeue(dumb_ptr<map_session_data> sd);
 int npc_event(dumb_ptr<map_session_data> sd, NpcEvent npcname, int);
-int npc_command(dumb_ptr<map_session_data> sd, NpcName npcname, XString command);
 int npc_touch_areanpc(dumb_ptr<map_session_data>, Borrowed<map_local>, int, int);
 int npc_click(dumb_ptr<map_session_data>, BlockId);
 int npc_scriptcont(dumb_ptr<map_session_data>, BlockId);

--- a/src/map/script-fun.cpp
+++ b/src/map/script-fun.cpp
@@ -2214,15 +2214,6 @@ void builtin_mapwarp(ScriptState *st)   // Added by RoVeRT
 }
 
 static
-void builtin_cmdothernpc(ScriptState *st)   // Added by RoVeRT
-{
-    NpcName npc = stringish<NpcName>(ZString(conv_str(st, &AARG(0))));
-    ZString command = ZString(conv_str(st, &AARG(1)));
-
-    npc_command(map_id2sd(st->rid), npc, command);
-}
-
-static
 void builtin_mobcount_sub(dumb_ptr<block_list> bl, NpcEvent event, int *c)
 {
     if (event == bl->is_mob()->npc_event)
@@ -3080,7 +3071,6 @@ BuiltinFunction builtin_functions[] =
     BUILTIN(pvpoff, "M"_s, '\0'),
     BUILTIN(emotion, "i"_s, '\0'),
     BUILTIN(mapwarp, "MMxy"_s, '\0'),
-    BUILTIN(cmdothernpc, "ss"_s, '\0'),
     BUILTIN(mobcount, "ME"_s, 'i'),
     BUILTIN(marriage, "P"_s, 'i'),
     BUILTIN(divorce, ""_s, 'i'),


### PR DESCRIPTION
cmdothernpc has been [deprecated on January 14th](https://github.com/themanaworld/tmwa-server-data/pull/247).
This PR removes it from existence 