### PR TITLE
deprecate gmcommand builtin

### DIFF
--- a/src/map/script-fun.cpp
+++ b/src/map/script-fun.cpp
@@ -687,6 +687,14 @@ void builtin_wgm(ScriptState *st)
             STRPRINTF("[GM] %s"_fmt, message));
 }
 
+static
+void builtin_gmlog(ScriptState *st)
+{
+    dumb_ptr<map_session_data> sd = script_rid2sd(st);
+    ZString message = ZString(conv_str(st, &AARG(0)));
+    log_atcommand(sd, STRPRINTF("{SCRIPT} %s"_fmt, message));
+}
+
 /*==========================================
  *
  *------------------------------------------
@@ -3177,6 +3185,7 @@ BuiltinFunction builtin_functions[] =
     BUILTIN(sc_check, "i"_s, 'i'),
     BUILTIN(debugmes, "s"_s, '\0'),
     BUILTIN(wgm, "s"_s, '\0'),
+    BUILTIN(gmlog, "s"_s, '\0'),
     BUILTIN(resetstatus, ""_s, '\0'),
     BUILTIN(changesex, ""_s, '\0'),
     BUILTIN(attachrid, "i"_s, 'i'),

--- a/src/map/script-fun.cpp
+++ b/src/map/script-fun.cpp
@@ -2610,25 +2610,6 @@ void builtin_unequipbyid(ScriptState *st)
 }
 
 /*==========================================
- * gmcommand [MouseJstr]
- *
- * suggested on the forums...
- *------------------------------------------
- */
-
-static
-void builtin_gmcommand(ScriptState *st)
-{
-    dumb_ptr<map_session_data> sd;
-
-    sd = script_rid2sd(st);
-    RString cmd = conv_str(st, &AARG(0));
-
-    is_atcommand(sd->sess, sd, cmd, GmLevel::from(-1U));
-
-}
-
-/*==========================================
  * npcwarp [remoitnane]
  * Move NPC to a new position on the same map.
  *------------------------------------------
@@ -3217,7 +3198,6 @@ BuiltinFunction builtin_functions[] =
     BUILTIN(specialeffect2, "i"_s, '\0'),
     BUILTIN(nude, ""_s, '\0'),
     BUILTIN(unequipbyid, "i"_s, '\0'),
-    BUILTIN(gmcommand, "s"_s, '\0'),
     BUILTIN(npcwarp, "xys"_s, '\0'),
     BUILTIN(npcareawarp, "xyxyis"_s, '\0'),
     BUILTIN(message, "Ps"_s, '\0'),

--- a/src/map/script-fun.cpp
+++ b/src/map/script-fun.cpp
@@ -677,6 +677,16 @@ void builtin_getelementofarray(ScriptState *st)
     }
 }
 
+static
+void builtin_wgm(ScriptState *st)
+{
+    ZString message = ZString(conv_str(st, &AARG(0)));
+
+    intif_wis_message_to_gm(WISP_SERVER_NAME,
+            battle_config.hack_info_GM_level,
+            STRPRINTF("[GM] %s"_fmt, message));
+}
+
 /*==========================================
  *
  *------------------------------------------
@@ -3166,6 +3176,7 @@ BuiltinFunction builtin_functions[] =
     BUILTIN(sc_end, "i"_s, '\0'),
     BUILTIN(sc_check, "i"_s, 'i'),
     BUILTIN(debugmes, "s"_s, '\0'),
+    BUILTIN(wgm, "s"_s, '\0'),
     BUILTIN(resetstatus, ""_s, '\0'),
     BUILTIN(changesex, ""_s, '\0'),
     BUILTIN(attachrid, "i"_s, 'i'),


### PR DESCRIPTION
This PR is to deprecate the gmcommand builtin.
It is [still used](https://github.com/themanaworld/tmwa-server-data/search?utf8=%E2%9C%93&q=gmcommand) for ```@l``` , ```@wgm``` , ```@alive``` , ```@killer``` , ```@killable``` and ```@blvl```

- - - 
the plan is:
:white_square_button: [deprecate killer and killable](https://github.com/themanaworld/tmwa/pull/41)
:white_square_button: make wgm into a builtin
:white_square_button: make log into a builtin
:white_square_button: [make ```heal``` automatically resurrect when hp is 0](https://github.com/themanaworld/tmwa/pull/50)
:white_square_button: [make scripts use wgm and gmlog builtins](https://github.com/themanaworld/tmwa-server-data/pull/323) & [fix fightclub](https://github.com/themanaworld/tmwa-server-data/pull/329)

and when all this is done: make a new PR to remove ```gmcommand```

---
### to merge:
1. merge this PR
2. merge https://github.com/themanaworld/tmwa-server-data/pull/323

~~later on, I will make another PR to remove the gmcommand builtin when https://github.com/themanaworld/tmwa-server-data/pull/329 is merged~~ Since it's already merged I will deprecate gmcommand directly in this PR