### PR TITLE
Do not require pk_mode for NOPVP

### DIFF
--- a/src/map/npc-parse.cpp
+++ b/src/map/npc-parse.cpp
@@ -339,7 +339,7 @@ bool npc_load_mapflag(ast::npc::MapFlag& mapflag)
         return false;
     }
 
-    if (battle_config.pk_mode && mf == MapFlag::NOPVP)
+    if (mf == MapFlag::NOPVP)
     {
         if (mapflag.vec_extra.data.size())
         {


### PR DESCRIPTION
this PR allows to set NOPVP (now used by the pvp channel system) without setting the server to pk mode