### PR TITLE
remove special warp names

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -2285,35 +2285,6 @@ int pc_setpos(dumb_ptr<map_session_data> sd,
 }
 
 /*==========================================
- * PCのランダムワープ
- *------------------------------------------
- */
-int pc_randomwarp(dumb_ptr<map_session_data> sd, BeingRemoveWhy type)
-{
-    int x, y, i = 0;
-
-    nullpo_retz(sd);
-
-    P<map_local> m = sd->bl_m;
-
-    if (sd->bl_m->flag.get(MapFlag::NOTELEPORT))  // テレポート禁止
-        return 0;
-
-    do
-    {
-        x = random_::in(1, m->xs - 2);
-        y = random_::in(1, m->ys - 2);
-    }
-    while (bool(read_gatp(m, x, y) & MapCell::UNWALKABLE)
-        && (i++) < 1000);
-
-    if (i < 1000)
-        pc_setpos(sd, m->name_, x, y, type);
-
-    return 0;
-}
-
-/*==========================================
  *
  *------------------------------------------
  */

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -91,7 +91,6 @@ int pc_walktoxy(dumb_ptr<map_session_data>, int, int);
 int pc_stop_walking(dumb_ptr<map_session_data>, int);
 int pc_setpos(dumb_ptr<map_session_data>, MapName, int, int, BeingRemoveWhy);
 void pc_setsavepoint(dumb_ptr<map_session_data>, MapName, int, int);
-int pc_randomwarp(dumb_ptr<map_session_data> sd, BeingRemoveWhy type);
 
 ADDITEM pc_checkadditem(dumb_ptr<map_session_data>, ItemNameId, int);
 int pc_inventoryblank(dumb_ptr<map_session_data>);

--- a/src/map/script-fun.cpp
+++ b/src/map/script-fun.cpp
@@ -338,22 +338,10 @@ void builtin_warp(ScriptState *st)
 {
     int x, y;
     dumb_ptr<map_session_data> sd = script_rid2sd(st);
-
     MapName str = stringish<MapName>(ZString(conv_str(st, &AARG(0))));
     x = conv_num(st, &AARG(1));
     y = conv_num(st, &AARG(2));
-    if (str == "Random"_s)
-        pc_randomwarp(sd, BeingRemoveWhy::WARPED);
-    else if (str == "SavePoint"_s or str == "Save"_s)
-    {
-        if (sd->bl_m->flag.get(MapFlag::NORETURN))
-            return;
-
-        pc_setpos(sd, sd->status.save_point.map_, sd->status.save_point.x, sd->status.save_point.y,
-                BeingRemoveWhy::WARPED);
-    }
-    else
-        pc_setpos(sd, str, x, y, BeingRemoveWhy::GONE);
+    pc_setpos(sd, str, x, y, BeingRemoveWhy::GONE);
 }
 
 /*==========================================
@@ -364,10 +352,7 @@ static
 void builtin_areawarp_sub(dumb_ptr<block_list> bl, MapName mapname, int x, int y)
 {
     dumb_ptr<map_session_data> sd = bl->is_player();
-    if (mapname == "Random"_s)
-        pc_randomwarp(sd, BeingRemoveWhy::WARPED);
-    else
-        pc_setpos(sd, mapname, x, y, BeingRemoveWhy::GONE);
+    pc_setpos(sd, mapname, x, y, BeingRemoveWhy::GONE);
 }
 
 static


### PR DESCRIPTION
"Save" and "SavePoint" is useless because of ```getsavepoint```

- - -
"Random" is useless because ```warp getmap(), 0, 0;``` does the same thing.