### PR TITLE
change sex without disconnecting

### DIFF
--- a/src/map/chrif.cpp
+++ b/src/map/chrif.cpp
@@ -615,9 +615,7 @@ void chrif_changedsex(Session *, const Packet_Fixed<0x2b0d>& fixed)
             chrif_save(sd);
             sd->login_id1++;    // change identify, because if player come back in char within the 5 seconds, he can change its characters
             // do same modify in login-server for the account, but no in char-server (it ask again login_id1 to login, and don't remember it)
-            clif_displaymessage(sd->sess,
-                                 "Your sex has been changed (need disconexion by the server)..."_s);
-            clif_setwaitclose(sd->sess); // forced to disconnect for the change
+            clif_fixpcpos(sd); // use clif_set0078_main_1d8 to send new sex to the client
         }
     }
     else

--- a/src/map/chrif.cpp
+++ b/src/map/chrif.cpp
@@ -609,8 +609,9 @@ void chrif_changedsex(Session *, const Packet_Fixed<0x2b0d>& fixed)
             {
                 if (sd->status.inventory[i].nameid
                     && bool(sd->status.inventory[i].equip))
-                    pc_unequipitem(sd, i, CalcStatus::NOW);
+                    pc_unequipitem(sd, i, CalcStatus::LATER);
             }
+            pc_calcstatus(sd, 0);
             // save character
             chrif_save(sd);
             sd->login_id1++;    // change identify, because if player come back in char within the 5 seconds, he can change its characters

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -3520,8 +3520,7 @@ int pc_setparam(dumb_ptr<map_session_data> sd, SP type, int val)
             }
             break;
         case SP::SEX:
-            // this is a really bad idea
-            sd->sex = static_cast<SEX>(val);
+            chrif_char_ask_name(AccountId(), sd->status_key.name, 5, HumanTimeDiff());
             break;
         case SP::WEIGHT:
             sd->weight = val;

--- a/src/map/script-fun.cpp
+++ b/src/map/script-fun.cpp
@@ -1987,20 +1987,6 @@ void builtin_resetstatus(ScriptState *st)
 }
 
 /*==========================================
- * 性別変換
- *------------------------------------------
- */
-static
-void builtin_changesex(ScriptState *st)
-{
-    dumb_ptr<map_session_data> sd = nullptr;
-    sd = script_rid2sd(st);
-
-    chrif_char_ask_name(AccountId(), sd->status_key.name, 5, HumanTimeDiff()); // type: 5 - changesex
-    chrif_save(sd);
-}
-
-/*==========================================
  * RIDのアタッチ
  *------------------------------------------
  */
@@ -3167,7 +3153,6 @@ BuiltinFunction builtin_functions[] =
     BUILTIN(sc_check, "i"_s, 'i'),
     BUILTIN(debugmes, "s"_s, '\0'),
     BUILTIN(resetstatus, ""_s, '\0'),
-    BUILTIN(changesex, ""_s, '\0'),
     BUILTIN(attachrid, "i"_s, 'i'),
     BUILTIN(detachrid, ""_s, '\0'),
     BUILTIN(isloggedin, "i"_s, 'i'),


### PR DESCRIPTION
Sex can now be sent the same way as classes (without kicking the player). No idea why this wasn't done before.. my guess is that perhaps Mana didn't have a packet to update char data.

- - -
## requires https://github.com/themanaworld/tmwa-server-data/pull/331