### PR TITLE
deprecate builtin readparam & statusup2

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -3547,7 +3547,7 @@ int pc_setparam(dumb_ptr<map_session_data> sd, SP type, int val)
         case SP::INT:
         case SP::DEX:
         case SP::LUK:
-            sd->status.attrs[sp_to_attr(type)] = val;
+            pc_statusup2(sd, type, (val - sd->status.attrs[sp_to_attr(type)]));
             break;
     }
     clif_updatestatus(sd, type);

--- a/src/map/script-fun.cpp
+++ b/src/map/script-fun.cpp
@@ -949,31 +949,6 @@ void builtin_delitem(ScriptState *st)
 }
 
 /*==========================================
- *キャラ関係のパラメータ取得
- *------------------------------------------
- */
-static
-void builtin_readparam(ScriptState *st)
-{
-    dumb_ptr<map_session_data> sd;
-
-    SP type = SP(conv_num(st, &AARG(0)));
-    if (HARG(1))
-        sd = map_nick2sd(stringish<CharName>(ZString(conv_str(st, &AARG(1)))));
-    else
-        sd = script_rid2sd(st);
-
-    if (sd == nullptr)
-    {
-        push_int<ScriptDataInt>(st->stack, -1);
-        return;
-    }
-
-    push_int<ScriptDataInt>(st->stack, pc_readparam(sd, type));
-
-}
-
-/*==========================================
  *キャラ関係のID取得
  *------------------------------------------
  */
@@ -1161,20 +1136,6 @@ void builtin_getequipname(ScriptState *st)
         buf = STRPRINTF("%s-[%s]"_fmt, pos_str[num - 1], pos_str[10]);
     }
     push_str<ScriptDataStr>(st->stack, buf);
-
-}
-
-/*==========================================
- *
- *------------------------------------------
- */
-static
-void builtin_statusup2(ScriptState *st)
-{
-    SP type = SP(conv_num(st, &AARG(0)));
-    int val = conv_num(st, &AARG(1));
-    dumb_ptr<map_session_data> sd = script_rid2sd(st);
-    pc_statusup2(sd, type, val);
 
 }
 
@@ -3124,12 +3085,10 @@ BuiltinFunction builtin_functions[] =
     BUILTIN(getitem, "Ii??"_s, '\0'),
     BUILTIN(makeitem, "IiMxy"_s, '\0'),
     BUILTIN(delitem, "Ii"_s, '\0'),
-    BUILTIN(readparam, "i?"_s, 'i'),
     BUILTIN(getcharid, "i?"_s, 'i'),
     BUILTIN(strcharinfo, "i"_s, 's'),
     BUILTIN(getequipid, "i"_s, 'i'),
     BUILTIN(getequipname, "i"_s, 's'),
-    BUILTIN(statusup2, "ii"_s, '\0'),
     BUILTIN(bonus, "ii"_s, '\0'),
     BUILTIN(bonus2, "iii"_s, '\0'),
     BUILTIN(skill, "ii?"_s, '\0'),


### PR DESCRIPTION
First of all, this PR deprecates the ```readparam``` builtin because it is integrated into the ```get_val``` (internal) builtin. This means that if const.txt in server-data is set properly you can directly get properties like ```Int``` without the need for readparam.

- - -
Secondly, I have made the ```set``` builtin do the same thing as ```statusup2``` when using params (does not affect normal variables).

This means that you can do things like ```set Str, Str - 9;``` and it will work as you would expect it to.

- - - 
***Note:*** The params are in the form ```Val``` but for bonus you need to use the form ```bVal```. For example: ```bonus bInt, -Int;```. This is because ```bVal``` is an integer but ```Val``` is a param (so it returns the value). Therefore ```bVit``` always equals 15 but ```Vit``` equals the actual vitality.

- - - 
## requires https://github.com/themanaworld/tmwa-server-data/pull/332