### PR TITLE
make emotion send to a single rid

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -198,11 +198,6 @@ int is_deaf(dumb_ptr<block_list> bl)
     return sd->special_state.deaf;
 }
 
-static
-void clif_emotion_towards(dumb_ptr<block_list> bl,
-                                  dumb_ptr<block_list> target, int type);
-
-
 enum class ChatType
 {
     Party,
@@ -3113,7 +3108,6 @@ void clif_emotion(dumb_ptr<block_list> bl, int type)
     clif_send(buf, bl, SendWho::AREA);
 }
 
-static
 void clif_emotion_towards(dumb_ptr<block_list> bl,
                                   dumb_ptr<block_list> target, int type)
 {

--- a/src/map/clif.hpp
+++ b/src/map/clif.hpp
@@ -96,6 +96,7 @@ int clif_changeoption(dumb_ptr<block_list>);   // area
 int clif_useitemack(dumb_ptr<map_session_data>, IOff0, int, int);    // self
 
 void clif_emotion(dumb_ptr<block_list> bl, int type);
+void clif_emotion_towards(dumb_ptr<block_list> bl, dumb_ptr<block_list> target, int type);
 void clif_sitting(Session *, dumb_ptr<map_session_data> sd);
 
 // trade

--- a/src/map/script-fun.cpp
+++ b/src/map/script-fun.cpp
@@ -2179,11 +2179,22 @@ void builtin_getpvpflag(ScriptState *st)
 static
 void builtin_emotion(ScriptState *st)
 {
-    int type;
-    type = conv_num(st, &AARG(0));
+    ZString str;
+    dumb_ptr<map_session_data> pl_sd = nullptr;
+    int type = conv_num(st, &AARG(0));
+    if (HARG(1)) {
+        str = ZString(conv_str(st, &AARG(1)));
+        CharName player = stringish<CharName>(str);
+        pl_sd = map_nick2sd(player);
+    }
     if (type < 0 || type > 200)
         return;
-    clif_emotion(map_id2bl(st->oid), type);
+    if (pl_sd != nullptr)
+        clif_emotion_towards(map_id2bl(st->oid), pl_sd, type);
+    else if (st->rid && str == "self"_s)
+        clif_emotion(map_id2sd(st->rid), type);
+    else
+        clif_emotion(map_id2bl(st->oid), type);
 }
 
 static
@@ -3178,7 +3189,7 @@ BuiltinFunction builtin_functions[] =
     BUILTIN(pvpoff, "M"_s, '\0'),
     BUILTIN(setpvpchannel, "i"_s, '\0'),
     BUILTIN(getpvpflag, "i"_s, 'i'),
-    BUILTIN(emotion, "i"_s, '\0'),
+    BUILTIN(emotion, "i?"_s, '\0'),
     BUILTIN(mapwarp, "MMxy"_s, '\0'),
     BUILTIN(mobcount, "ME"_s, 'i'),
     BUILTIN(marriage, "P"_s, 'i'),


### PR DESCRIPTION
```emotion x;``` display on the npc and send to all
```emotion x, strcharinfo(0);``` display on the npc and send to the specified player
```emotion x, "self";``` display on the attached rid and send to all 

- - - 
## requires https://github.com/themanaworld/tmwa-server-data/pull/338