### PR TITLE
make freeloop check the value

### DIFF
--- a/src/map/script-call.cpp
+++ b/src/map/script-call.cpp
@@ -757,7 +757,7 @@ void run_script_main(ScriptState *st, Borrowed<const ScriptBuffer> rootscript)
                 {
                     rerun_pos = st->scriptp.pos;
                     st->state = ScriptEndState::ZERO;
-                    if (!st->freeloop && gotocount > 0 && (--gotocount) <= 0)
+                    if (st->freeloop != 1 && gotocount > 0 && (--gotocount) <= 0)
                     {
                         PRINTF("run_script: infinity loop !\n"_fmt);
                         st->state = ScriptEndState::END;
@@ -806,7 +806,7 @@ void run_script_main(ScriptState *st, Borrowed<const ScriptBuffer> rootscript)
                 st->state = ScriptEndState::END;
                 break;
         }
-        if (!st->freeloop && cmdcount > 0 && (--cmdcount) <= 0)
+        if (st->freeloop != 1 && cmdcount > 0 && (--cmdcount) <= 0)
         {
             PRINTF("run_script: infinity loop !\n"_fmt);
             st->state = ScriptEndState::END;


### PR DESCRIPTION
I discovered a bug with freeloop. Basically it was always on unless you explicitly do `freeloop 0;` on server start.