### PR TITLE
Remove useless events

### DIFF
--- a/src/map/chrif.cpp
+++ b/src/map/chrif.cpp
@@ -249,9 +249,6 @@ int chrif_connectack(Session *s, const Packet_Fixed<0x2af9>& fixed)
 
     chrif_sendmap(s);
 
-    PRINTF("chrif: OnInterIfInit event done. (%d events)\n"_fmt,
-            npc_event_doall(stringish<ScriptLabel>("OnInterIfInit"_s)));
-
     return 0;
 }
 

--- a/src/map/chrif.cpp
+++ b/src/map/chrif.cpp
@@ -249,8 +249,6 @@ int chrif_connectack(Session *s, const Packet_Fixed<0x2af9>& fixed)
 
     chrif_sendmap(s);
 
-    PRINTF("chrif: OnCharIfInit event done. (%d events)\n"_fmt,
-            npc_event_doall(stringish<ScriptLabel>("OnCharIfInit"_s)));
     PRINTF("chrif: OnInterIfInit event done. (%d events)\n"_fmt,
             npc_event_doall(stringish<ScriptLabel>("OnInterIfInit"_s)));
 


### PR DESCRIPTION
I removed `OnCharIfInit` because it was a duplicate of the event `OnInterIfInit` (nothing in between the 2 events)
<hr/>
At first, I thought `OnInterIfInit` came before `OnInit` but I was wrong; it is executed after the map server connects to the char server so it's after `OnInit`. Why would you EVER need to wait for char server to do operations that do not require an attached rid? We don't use it and not even hercules found a use for it so I removed it.