### PR TITLE
wait for the player to be added to block list

### DIFF
--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -2498,7 +2498,7 @@ ATCE atcommand_doom(Session *s, dumb_ptr<map_session_data> sd,
         if (!s2)
             continue;
         dumb_ptr<map_session_data> pl_sd = dumb_ptr<map_session_data>(static_cast<map_session_data *>(s2->session_data.get()));
-        if (pl_sd
+        if (pl_sd && !pl_sd->state.connect_new
             && pl_sd->state.auth && s2 != s
             && pc_isGM(sd).overwhelms(pc_isGM(pl_sd)))
         {
@@ -2522,7 +2522,7 @@ ATCE atcommand_doommap(Session *s, dumb_ptr<map_session_data> sd,
         if (!s2)
             continue;
         dumb_ptr<map_session_data> pl_sd = dumb_ptr<map_session_data>(static_cast<map_session_data *>(s2->session_data.get()));
-        if (pl_sd
+        if (pl_sd && !pl_sd->state.connect_new
             && pl_sd->state.auth && s2 != s && sd->bl_m == pl_sd->bl_m
             && pc_isGM(sd).overwhelms(pc_isGM(pl_sd)))
         {
@@ -3474,7 +3474,7 @@ ATCE atcommand_partyrecall(Session *s, dumb_ptr<map_session_data> sd,
                 if (!s2)
                     continue;
                 dumb_ptr<map_session_data> pl_sd = dumb_ptr<map_session_data>(static_cast<map_session_data *>(s2->session_data.get()));
-                if (pl_sd && pl_sd->state.auth
+                if (pl_sd && pl_sd->state.auth && !pl_sd->state.connect_new
                     && sd->status_key.account_id != pl_sd->status_key.account_id
                     && pl_sd->status.party_id == p.party_id)
                 {
@@ -3889,7 +3889,7 @@ ATCE atcommand_effect(Session *s, dumb_ptr<map_session_data> sd,
             if (!s2)
                 continue;
             dumb_ptr<map_session_data> pl_sd = dumb_ptr<map_session_data>(static_cast<map_session_data *>(s2->session_data.get()));
-            if (pl_sd && pl_sd->state.auth)
+            if (pl_sd && pl_sd->state.auth && !pl_sd->state.connect_new)
             {
                 clif_specialeffect(pl_sd, type, flag);
                 clif_displaymessage(pl_sd->sess, "Your Effect Has Changed."_s);
@@ -4920,7 +4920,7 @@ ATCE atcommand_doomspot(Session *s, dumb_ptr<map_session_data> sd,
         if (!s2)
             continue;
         dumb_ptr<map_session_data> pl_sd = dumb_ptr<map_session_data>(static_cast<map_session_data *>(s2->session_data.get()));
-        if (pl_sd
+        if (pl_sd && !pl_sd->state.connect_new
             && pl_sd->state.auth && s2 != s && sd->bl_m == pl_sd->bl_m
             && sd->bl_x == pl_sd->bl_x && sd->bl_y == pl_sd->bl_y
             && pc_isGM(sd).overwhelms(pc_isGM(pl_sd)))

--- a/src/map/chrif.cpp
+++ b/src/map/chrif.cpp
@@ -1037,7 +1037,7 @@ void send_users_tochar(TimerData *, tick_t)
         if (!s)
             continue;
         dumb_ptr<map_session_data> sd = dumb_ptr<map_session_data>(static_cast<map_session_data *>(s->session_data.get()));
-        if (sd && sd->state.auth &&
+        if (sd && sd->state.auth && !sd->state.connect_new &&
             !((battle_config.hide_GM_session
                || sd->state.shroud_active
                || bool(sd->status.option & Opt0::HIDE)) && pc_isGM(sd)))

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -165,7 +165,7 @@ int clif_countusers(void)
         if (!s)
             continue;
         dumb_ptr<map_session_data> sd = dumb_ptr<map_session_data>(static_cast<map_session_data *>(s->session_data.get()));
-        if (sd && sd->state.auth && !(battle_config.hide_GM_session && pc_isGM(sd)))
+        if (sd && sd->state.auth && !sd->state.connect_new && !(battle_config.hide_GM_session && pc_isGM(sd)))
             users++;
     }
     return users;
@@ -183,7 +183,7 @@ int clif_foreachclient(std::function<void (dumb_ptr<map_session_data>)> func)
         if (!s)
             continue;
         dumb_ptr<map_session_data> sd = dumb_ptr<map_session_data>(static_cast<map_session_data *>(s->session_data.get()));
-        if (sd && sd->state.auth)
+        if (sd && sd->state.auth && !sd->state.connect_new)
             func(sd);
     }
     return 0;
@@ -295,7 +295,7 @@ int clif_send(const Buffer& buf, dumb_ptr<block_list> bl, SendWho type)
                 if (!s)
                     continue;
                 dumb_ptr<map_session_data> sd = dumb_ptr<map_session_data>(static_cast<map_session_data *>(s->session_data.get()));
-                if (sd && sd->state.auth)
+                if (sd && sd->state.auth && !sd->state.connect_new)
                 {
                     {
                         send_buffer(s, buf);
@@ -310,7 +310,7 @@ int clif_send(const Buffer& buf, dumb_ptr<block_list> bl, SendWho type)
                 if (!s)
                     continue;
                 dumb_ptr<map_session_data> sd = dumb_ptr<map_session_data>(static_cast<map_session_data *>(s->session_data.get()));
-                if (sd && sd->state.auth && sd->bl_m == bl->bl_m)
+                if (sd && sd->state.auth && !sd->state.connect_new && sd->bl_m == bl->bl_m)
                 {
                     {
                         send_buffer(s, buf);
@@ -388,7 +388,7 @@ int clif_send(const Buffer& buf, dumb_ptr<block_list> bl, SendWho type)
                     if (!s)
                         continue;
                     dumb_ptr<map_session_data> sd = dumb_ptr<map_session_data>(static_cast<map_session_data *>(s->session_data.get()));
-                    if (sd && sd->state.auth)
+                    if (sd && sd->state.auth && !sd->state.connect_new)
                     {
                         if (sd->partyspy == p.party_id)
                         {
@@ -3221,7 +3221,7 @@ int clif_specialeffect(dumb_ptr<block_list> bl, int type, int flag)
             if (!s)
                 continue;
             dumb_ptr<map_session_data> sd = dumb_ptr<map_session_data>(static_cast<map_session_data *>(s->session_data.get()));
-            if (sd && sd->state.auth && sd->bl_m == bl->bl_m)
+            if (sd && sd->state.auth && !sd->state.connect_new && sd->bl_m == bl->bl_m)
                 clif_specialeffect(sd, type, 1);
         }
     }

--- a/src/map/intif.cpp
+++ b/src/map/intif.cpp
@@ -359,7 +359,7 @@ void mapif_parse_WisToGM(Session *, const Packet_Head<0x3803>& head, AString& me
         if (!s2)
             continue;
         dumb_ptr<map_session_data> pl_sd = dumb_ptr<map_session_data>(static_cast<map_session_data *>(s2->session_data.get()));
-        if (pl_sd && pl_sd->state.auth)
+        if (pl_sd && pl_sd->state.auth && !pl_sd->state.connect_new)
         {
             if (pc_isGM(pl_sd).satisfies(min_gm_level))
                 clif_wis_message(s2, Wisp_name, message);

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -913,7 +913,7 @@ dumb_ptr<map_session_data> map_get_session(io::FD i)
         if (!s)
             return nullptr;
         map_session_data *d = static_cast<map_session_data *>(s->session_data.get());
-        if (d && d->state.auth)
+        if (d && d->state.auth && !d->state.connect_new)
             return dumb_ptr<map_session_data>(d);
     }
 

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -809,7 +809,7 @@ void pc_show_motd(dumb_ptr<map_session_data> sd)
     // If you remove the sending of this message,
     // the license does not permit you to publicly use this software.
 
-    clif_displaymessage(sd->sess, "This server is Free Software, for details type @source in chat or use the tmwa-source tool"_s);
+    clif_displaymessage(sd->sess, "##7Server : This server is Free Software, for details type @source in chat or use the tmwa-source tool"_s);
     npc_event_doall_l(stringish<ScriptLabel>("OnPCLoginEvent"_s), sd->bl_id, nullptr);
 
     sd->state.seen_motd = true;

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -801,8 +801,6 @@ int pc_authok(AccountId id, int login_id2,
     return 0;
 }
 
-// TODO fix this to cache and use inotify
-// this is far from the only such thing, but most of the others are logs
 void pc_show_motd(dumb_ptr<map_session_data> sd)
 {
     // Attention all forks: DO NOT REMOVE THIS NOTICE.
@@ -815,15 +813,6 @@ void pc_show_motd(dumb_ptr<map_session_data> sd)
     npc_event_doall_l(stringish<ScriptLabel>("OnPCLoginEvent"_s), sd->bl_id, nullptr);
 
     sd->state.seen_motd = true;
-    io::ReadFile in(map_conf.motd_txt);
-    if (in.is_open())
-    {
-        AString buf;
-        while (in.getline(buf))
-        {
-            clif_displaymessage(sd->sess, buf);
-        }
-    }
 }
 
 /*==========================================

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -517,6 +517,7 @@ int pc_setnewpc(dumb_ptr<map_session_data> sd, AccountId account_id, CharId char
     (void)client_tick;
     sd->sex = sex;
     sd->state.auth = 0;
+    sd->state.connect_new = 0;
     sd->bl_type = BL::PC;
     sd->canact_tick = sd->canmove_tick = gettick();
     sd->canlog_tick = gettick();
@@ -795,7 +796,6 @@ int pc_authok(AccountId id, int login_id2,
 
     pc_calcstatus(sd, 1);
 
-    npc_event_doall_l(stringish<ScriptLabel>("OnPCLoginEvent"_s), sd->bl_id, nullptr);
     // Init Quest Log
     clif_sendallquest(sd);
     return 0;
@@ -812,6 +812,7 @@ void pc_show_motd(dumb_ptr<map_session_data> sd)
     // the license does not permit you to publicly use this software.
 
     clif_displaymessage(sd->sess, "This server is Free Software, for details type @source in chat or use the tmwa-source tool"_s);
+    npc_event_doall_l(stringish<ScriptLabel>("OnPCLoginEvent"_s), sd->bl_id, nullptr);
 
     sd->state.seen_motd = true;
     io::ReadFile in(map_conf.motd_txt);

--- a/tools/config.py
+++ b/tools/config.py
@@ -573,7 +573,6 @@ def build_config():
     map_conf.opt('npc', addnpc, '{}')
     map_conf.opt('delnpc', delnpc, '{}')
     map_conf.opt('autosave_time', seconds, 'DEFAULT_AUTOSAVE_INTERVAL', {map_h})
-    map_conf.opt('motd_txt', RString, lit('conf/motd.txt'))
     map_conf.opt('mapreg_txt', RString, lit('save/mapreg.txt'))
     map_conf.opt('gm_log', RString, '{}')
     map_conf.opt('log_file', RString, '{}')


### PR DESCRIPTION
The player is only added to the map block list after the client sends `0x007d` so since the player is not in the list yet it is not sent to other players but it appears in the list and you can `@hugo` and `@goto` to them.

When the client connects to the server it sets `connect_new` to 0 and `auth` to 0. Then it waits for the client to authenticate and sets them both to 1. Finally, the first time the client loads a map it sets `connect_new` to 0. When `connect_new` is 0 and `auth` is 1 we can finally say the player is connected.

I also moved onlogin to after the motd because if we want onlogin to send messages to the player and not only set vars we should wait for the client to be ready.