### PR TITLE
Pvp enhancements

### DIFF
--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -4108,6 +4108,9 @@ ATCE atcommand_pvp(Session *s, dumb_ptr<map_session_data> sd,
         clif_displaymessage(s, "##3PvP : ##BOff"_s);
     }
 
+    sd->state.pvp_rank = 0;
+    clif_pvpstatus(sd); // send my channel to others
+
     pc_setpvptimer(sd, battle_config.player_pvp_time);
     return ATCE::OKAY;
 }
@@ -4127,6 +4130,8 @@ ATCE atcommand_charpvp(Session *, dumb_ptr<map_session_data>,
         return ATCE::EXIST;
 
     pl_sd->state.pvpchannel = channel;
+    pl_sd->state.pvp_rank = 0;
+    clif_pvpstatus(pl_sd); // send their channel to others
 
     return ATCE::OKAY;
 }

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -842,7 +842,7 @@ void clif_0225_being_move3_sub(dumb_ptr<block_list> bl, const Buffer& buf)
 
     if (sd->sess != nullptr)
     {
-        if(sd->client_version >= 3)
+        if(sd->client_version >= 3) // require 1.5.5.23 or above
         {
             send_buffer(sd->sess, buf);
         }
@@ -2054,7 +2054,7 @@ void clif_map_pvp(dumb_ptr<map_session_data> sd)
 {
     nullpo_retv(sd);
 
-    if (sd->client_version < 3)
+    if (sd->client_version < 2) // require 1.5.5.9 or above
         return;
 
     Packet_Fixed<0x0199> fixed_199;
@@ -2067,6 +2067,9 @@ void clif_map_pvp(dumb_ptr<map_session_data> sd)
 void clif_pvpstatus(dumb_ptr<map_session_data> sd)
 {
     nullpo_retv(sd);
+
+    if (sd->client_version < 2) // require 1.5.5.9 or above
+        return;
 
     Packet_Fixed<0x019a> fixed_19a;
     fixed_19a.block_id = sd->bl_id;
@@ -2716,7 +2719,7 @@ void clif_skillinfoblock(dumb_ptr<map_session_data> sd)
     std::vector<Packet_Repeat<0x010f>> repeat_10f;
     for (SkillID i : erange(SkillID(), MAX_SKILL))
     {
-        if (sd->status.skill[i].lv && sd->client_version >= 1)
+        if (sd->status.skill[i].lv)
         {
             Packet_Repeat<0x010f> info;
             // [Fate] Version 1 and later don't crash because of bad skill IDs anymore
@@ -4848,7 +4851,7 @@ void clif_sendallquest(dumb_ptr<map_session_data> sd)
     if (!sd->sess)
         return;
 
-    if(sd->client_version < 2)
+    if(sd->client_version < 2) // require 1.5.5.9 or above
         return;
 
     Session *s = sd->sess;
@@ -4885,7 +4888,7 @@ void clif_sendquest(dumb_ptr<map_session_data> sd, QuestId questid, int value)
     if (!sd->sess)
         return;
 
-    if(sd->client_version < 2)
+    if(sd->client_version < 2) // require 1.5.5.9 or above
         return;
 
     Session *s = sd->sess;

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -217,7 +217,7 @@ AString clif_validate_chat(dumb_ptr<map_session_data> sd, ChatType type, XString
  */
 static
 void clif_send_sub(dumb_ptr<block_list> bl, const Buffer& buf,
-        dumb_ptr<block_list> src_bl, SendWho type)
+        dumb_ptr<block_list> src_bl, SendWho type, short min_version)
 {
     nullpo_retv(bl);
     dumb_ptr<map_session_data> sd = bl->is_player();
@@ -246,6 +246,7 @@ void clif_send_sub(dumb_ptr<block_list> bl, const Buffer& buf,
     if (sd->sess != nullptr)
     {
         {
+            if (sd->client_version >= min_version)
             {
                 send_buffer(sd->sess, buf);
             }
@@ -258,7 +259,7 @@ void clif_send_sub(dumb_ptr<block_list> bl, const Buffer& buf,
  *------------------------------------------
  */
 static
-int clif_send(const Buffer& buf, dumb_ptr<block_list> bl, SendWho type)
+int clif_send(const Buffer& buf, dumb_ptr<block_list> bl, SendWho type, short min_version)
 {
     int x0 = 0, x1 = 0, y0 = 0, y1 = 0;
 
@@ -323,14 +324,14 @@ int clif_send(const Buffer& buf, dumb_ptr<block_list> bl, SendWho type)
             break;
         case SendWho::AREA:
         case SendWho::AREA_WOS:
-            map_foreachinarea(std::bind(clif_send_sub, ph::_1, buf, bl, type),
+            map_foreachinarea(std::bind(clif_send_sub, ph::_1, buf, bl, type, min_version),
                     bl->bl_m,
                     bl->bl_x - AREA_SIZE, bl->bl_y - AREA_SIZE,
                     bl->bl_x + AREA_SIZE, bl->bl_y + AREA_SIZE,
                     BL::PC);
             break;
         case SendWho::AREA_CHAT_WOC:
-            map_foreachinarea(std::bind(clif_send_sub, ph::_1, buf, bl, SendWho::AREA_CHAT_WOC),
+            map_foreachinarea(std::bind(clif_send_sub, ph::_1, buf, bl, SendWho::AREA_CHAT_WOC, min_version),
                     bl->bl_m,
                     bl->bl_x - (AREA_SIZE), bl->bl_y - (AREA_SIZE),
                     bl->bl_x + (AREA_SIZE), bl->bl_y + (AREA_SIZE),
@@ -380,6 +381,7 @@ int clif_send(const Buffer& buf, dumb_ptr<block_list> bl, SendWho type)
                             (sd->bl_x < x0 || sd->bl_y < y0 ||
                              sd->bl_x > x1 || sd->bl_y > y1))
                             continue;
+                        if (sd->client_version >= min_version)
                         {
                             send_buffer(sd->sess, buf);
                         }
@@ -395,6 +397,7 @@ int clif_send(const Buffer& buf, dumb_ptr<block_list> bl, SendWho type)
                     {
                         if (sd->partyspy == p.party_id)
                         {
+                            if (sd->client_version >= min_version)
                             {
                                 send_buffer(sd->sess, buf);
                             }
@@ -410,7 +413,8 @@ int clif_send(const Buffer& buf, dumb_ptr<block_list> bl, SendWho type)
             dumb_ptr<map_session_data> sd = bl->is_player();
 
             {
-                send_buffer(sd->sess, buf);
+                if (sd->client_version >= min_version)
+                    send_buffer(sd->sess, buf);
             }
         }
             break;
@@ -528,7 +532,7 @@ int clif_dropflooritem(dumb_ptr<flooritem_data> fitem)
 
     Buffer buf;
     clif_set009e(fitem, buf);
-    clif_send(buf, fitem, SendWho::AREA);
+    clif_send(buf, fitem, SendWho::AREA, MIN_CLIENT_VERSION);
 
     return 0;
 }
@@ -547,7 +551,7 @@ int clif_clearflooritem(dumb_ptr<flooritem_data> fitem, Session *s)
     if (!s)
     {
         Buffer buf = create_fpacket<0x00a1, 6>(fixed_a1);
-        clif_send(buf, fitem, SendWho::AREA);
+        clif_send(buf, fitem, SendWho::AREA, MIN_CLIENT_VERSION);
     }
     else
     {
@@ -572,14 +576,14 @@ int clif_clearchar(dumb_ptr<block_list> bl, BeingRemoveWhy type)
     {
         fixed_80.type = BeingRemoveWhy::GONE;
         Buffer buf = create_fpacket<0x0080, 7>(fixed_80);
-        clif_send(buf, bl, SendWho::AREA);
+        clif_send(buf, bl, SendWho::AREA, MIN_CLIENT_VERSION);
     }
     else
     {
         fixed_80.type = type;
         Buffer buf = create_fpacket<0x0080, 7>(fixed_80);
         clif_send(buf, bl,
-                   type == BeingRemoveWhy::DEAD ? SendWho::AREA : SendWho::AREA_WOS);
+                   type == BeingRemoveWhy::DEAD ? SendWho::AREA : SendWho::AREA_WOS, MIN_CLIENT_VERSION);
     }
 
     return 0;
@@ -835,21 +839,6 @@ void clif_mob007b(dumb_ptr<mob_data> md, Buffer& buf)
  *------------------------------------------
  */
 static
-void clif_0225_being_move3_sub(dumb_ptr<block_list> bl, const Buffer& buf)
-{
-    nullpo_retv(bl);
-    dumb_ptr<map_session_data> sd = bl->is_player();
-
-    if (sd->sess != nullptr)
-    {
-        if(sd->client_version >= 3) // require 1.5.5.23 or above
-        {
-            send_buffer(sd->sess, buf);
-        }
-    }
-}
-
-static
 int clif_0225_being_move3(dumb_ptr<mob_data> md)
 {
     Packet_Head<0x0225> head_225;
@@ -869,11 +858,7 @@ int clif_0225_being_move3(dumb_ptr<mob_data> md)
 
     Buffer buf = create_vpacket<0x0225, 14, 1>(head_225, repeat_225);
 
-    map_foreachinarea(std::bind(clif_0225_being_move3_sub, ph::_1, buf),
-            md->bl_m,
-            md->bl_x - AREA_SIZE, md->bl_y - AREA_SIZE,
-            md->bl_x + AREA_SIZE, md->bl_y + AREA_SIZE,
-            BL::PC);
+    clif_send(buf, md, SendWho::AREA, 3);
 
     return 0;
 }
@@ -928,7 +913,7 @@ int clif_spawnpc(dumb_ptr<map_session_data> sd)
     Buffer buf;
     clif_set0078_alt_1d9(sd, buf);
 
-    clif_send(buf, sd, SendWho::AREA_WOS);
+    clif_send(buf, sd, SendWho::AREA_WOS, MIN_CLIENT_VERSION);
 
     clif_pvpstatus(sd);
 
@@ -967,17 +952,17 @@ int clif_spawnnpc(dumb_ptr<npc_data> nd)
     fixed_7c.pos.y = nd->bl_y;
 
     Buffer buf = create_fpacket<0x007c, 41>(fixed_7c);
-    clif_send(buf, nd, SendWho::AREA);
+    clif_send(buf, nd, SendWho::AREA, MIN_CLIENT_VERSION);
     */
     Buffer buf;
     clif_npc0078(nd, buf);
-    clif_send(buf, nd, SendWho::AREA);
+    clif_send(buf, nd, SendWho::AREA, MIN_CLIENT_VERSION);
 
     if(nd->sit == DamageType::SIT)
     {
         Buffer buff;
         clif_sitnpc_sub(buff, nd, nd->sit);
-        clif_send(buff, nd, SendWho::AREA);
+        clif_send(buff, nd, SendWho::AREA, MIN_CLIENT_VERSION);
     }
 
     return 0;
@@ -1036,12 +1021,12 @@ int clif_spawnmob(dumb_ptr<mob_data> md)
         fixed_7c.pos.x = md->bl_x;
         fixed_7c.pos.y = md->bl_y;
         Buffer buf = create_fpacket<0x007c, 41>(fixed_7c);
-        clif_send(buf, md, SendWho::AREA);
+        clif_send(buf, md, SendWho::AREA, MIN_CLIENT_VERSION);
     }
 
     Buffer buf;
     clif_mob0078(md, buf);
-    clif_send(buf, md, SendWho::AREA);
+    clif_send(buf, md, SendWho::AREA, MIN_CLIENT_VERSION);
 
     return 0;
 }
@@ -1095,7 +1080,7 @@ int clif_movechar(dumb_ptr<map_session_data> sd)
     Buffer buf;
     clif_set007b(sd, buf);
 
-    clif_send(buf, sd, SendWho::AREA_WOS);
+    clif_send(buf, sd, SendWho::AREA_WOS, MIN_CLIENT_VERSION);
 
     if (battle_config.save_clothcolor == 1 && sd->status.clothes_color > 0)
         clif_changelook(sd, LOOK::CLOTHES_COLOR,
@@ -1187,7 +1172,7 @@ void clif_fixpos(dumb_ptr<block_list> bl)
     fixed_88.y = bl->bl_y;
 
     Buffer buf = create_fpacket<0x0088, 10>(fixed_88);
-    clif_send(buf, bl, SendWho::AREA);
+    clif_send(buf, bl, SendWho::AREA, MIN_CLIENT_VERSION);
 }
 
 /*==========================================
@@ -1865,9 +1850,9 @@ int clif_changelook_towards(dumb_ptr<block_list> bl, LOOK type, int val,
 
         Buffer buf = create_fpacket<0x01d7, 11>(fixed_1d7);
         if (dstsd)
-            clif_send(buf, dstsd, SendWho::SELF);
+            clif_send(buf, dstsd, SendWho::SELF, MIN_CLIENT_VERSION);
         else
-            clif_send(buf, bl, SendWho::AREA);
+            clif_send(buf, bl, SendWho::AREA, MIN_CLIENT_VERSION);
     }
     else
     {
@@ -1879,9 +1864,9 @@ int clif_changelook_towards(dumb_ptr<block_list> bl, LOOK type, int val,
 
         Buffer buf = create_fpacket<0x01d7, 11>(fixed_1d7);
         if (dstsd)
-            clif_send(buf, dstsd, SendWho::SELF);
+            clif_send(buf, dstsd, SendWho::SELF, MIN_CLIENT_VERSION);
         else
-            clif_send(buf, bl, SendWho::AREA);
+            clif_send(buf, bl, SendWho::AREA, MIN_CLIENT_VERSION);
     }
     return 0;
 }
@@ -2045,7 +2030,7 @@ int clif_misceffect(dumb_ptr<block_list> bl, int type)
     fixed_19b.type = type;
     Buffer buf = create_fpacket<0x019b, 10>(fixed_19b);
 
-    clif_send(buf, bl, SendWho::AREA);
+    clif_send(buf, bl, SendWho::AREA, MIN_CLIENT_VERSION);
 
     return 0;
 }
@@ -2054,30 +2039,31 @@ void clif_map_pvp(dumb_ptr<map_session_data> sd)
 {
     nullpo_retv(sd);
 
-    if (sd->client_version < 2) // require 1.5.5.9 or above
-        return;
-
     Packet_Fixed<0x0199> fixed_199;
     fixed_199.status = sd->bl_m->flag.get(MapFlag::PVP)? 1: 0;
     Buffer buf = create_fpacket<0x0199, 4>(fixed_199);
 
-    clif_send(buf, sd, SendWho::SELF);
+    clif_send(buf, sd, SendWho::SELF, 2);
 }
 
-void clif_pvpstatus(dumb_ptr<map_session_data> sd)
+static
+void clif_pvpstatus_towards(Buffer& buf, dumb_ptr<map_session_data> sd)
 {
     nullpo_retv(sd);
-
-    if (sd->client_version < 2) // require 1.5.5.9 or above
-        return;
 
     Packet_Fixed<0x019a> fixed_19a;
     fixed_19a.block_id = sd->bl_id;
     fixed_19a.rank = sd->state.pvp_rank;
     fixed_19a.channel = sd->state.pvpchannel;
-    Buffer buf = create_fpacket<0x019a, 14>(fixed_19a);
+    buf = create_fpacket<0x019a, 14>(fixed_19a);
+}
 
-    clif_send(buf, sd, SendWho::AREA);
+void clif_pvpstatus(dumb_ptr<map_session_data> sd)
+{
+    nullpo_retv(sd);
+    Buffer buf;
+    clif_pvpstatus_towards(buf, sd);
+    clif_send(buf, sd, SendWho::AREA, 2);
 }
 
 /*==========================================
@@ -2101,7 +2087,7 @@ int clif_changeoption(dumb_ptr<block_list> bl)
     fixed_119.zero = 0;
     Buffer buf = create_fpacket<0x0119, 13>(fixed_119);
 
-    clif_send(buf, bl, SendWho::AREA);
+    clif_send(buf, bl, SendWho::AREA, MIN_CLIENT_VERSION);
 
     return 0;
 }
@@ -2133,7 +2119,7 @@ int clif_useitemack(dumb_ptr<map_session_data> sd, IOff0 index, int amount,
         fixed_1c8.amount = amount;
         fixed_1c8.ok = ok;
         Buffer buf = create_fpacket<0x01c8, 13>(fixed_1c8);
-        clif_send(buf, sd, SendWho::SELF);
+        clif_send(buf, sd, SendWho::SELF, MIN_CLIENT_VERSION);
     }
 
     return 0;
@@ -2388,6 +2374,10 @@ void clif_getareachar_pc(dumb_ptr<map_session_data> sd,
     }
     send_buffer(sd->sess, buf);
 
+    Buffer buff;
+    clif_pvpstatus_towards(buff, dstsd);
+    clif_send(buff, sd, SendWho::SELF, 2);
+
     if (battle_config.save_clothcolor == 1 && dstsd->status.clothes_color > 0)
         clif_changelook(dstsd, LOOK::CLOTHES_COLOR,
                          dstsd->status.clothes_color);
@@ -2431,7 +2421,7 @@ int clif_movemob(dumb_ptr<mob_data> md)
 
     Buffer buf;
     clif_mob007b(md, buf);
-    clif_send(buf, md, SendWho::AREA);
+    clif_send(buf, md, SendWho::AREA, MIN_CLIENT_VERSION);
     clif_0225_being_move3(md);
 
     return 0;
@@ -2449,13 +2439,13 @@ int clif_fixmobpos(dumb_ptr<mob_data> md)
     {
         Buffer buf;
         clif_mob007b(md, buf);
-        clif_send(buf, md, SendWho::AREA);
+        clif_send(buf, md, SendWho::AREA, MIN_CLIENT_VERSION);
     }
     else
     {
         Buffer buf;
         clif_mob0078(md, buf);
-        clif_send(buf, md, SendWho::AREA);
+        clif_send(buf, md, SendWho::AREA, MIN_CLIENT_VERSION);
     }
 
     return 0;
@@ -2473,13 +2463,13 @@ int clif_fixpcpos(dumb_ptr<map_session_data> sd)
     {
         Buffer buf;
         clif_set007b(sd, buf);
-        clif_send(buf, sd, SendWho::AREA);
+        clif_send(buf, sd, SendWho::AREA, MIN_CLIENT_VERSION);
     }
     else
     {
         Buffer buf;
         clif_set0078_main_1d8(sd, buf);
-        clif_send(buf, sd, SendWho::AREA);
+        clif_send(buf, sd, SendWho::AREA, MIN_CLIENT_VERSION);
     }
     clif_changelook_accessories(sd, nullptr);
 
@@ -2512,7 +2502,7 @@ int clif_damage(dumb_ptr<block_list> src, dumb_ptr<block_list> dst,
     fixed_8a.damage_type = type;
     fixed_8a.damage2 = 0;
     Buffer buf = create_fpacket<0x008a, 29>(fixed_8a);
-    clif_send(buf, src, SendWho::AREA);
+    clif_send(buf, src, SendWho::AREA, MIN_CLIENT_VERSION);
 
     return 0;
 }
@@ -2834,7 +2824,7 @@ int clif_skill_damage(dumb_ptr<block_list> src, dumb_ptr<block_list> dst,
     fixed_1de.div = div;
     fixed_1de.type_or_hit = (type > 0) ? type : skill_get_hit(skill_id);
     Buffer buf = create_fpacket<0x01de, 33>(fixed_1de);
-    clif_send(buf, src, SendWho::AREA);
+    clif_send(buf, src, SendWho::AREA, MIN_CLIENT_VERSION);
 
     return 0;
 }
@@ -2852,7 +2842,7 @@ int clif_status_change(dumb_ptr<block_list> bl, StatusChange type, int flag)
     fixed_196.block_id = bl->bl_id;
     fixed_196.flag = flag;
     Buffer buf = create_fpacket<0x0196, 9>(fixed_196);
-    clif_send(buf, bl, SendWho::AREA);
+    clif_send(buf, bl, SendWho::AREA, MIN_CLIENT_VERSION);
     return 0;
 }
 
@@ -2882,7 +2872,7 @@ void clif_GMmessage(dumb_ptr<block_list> bl, XString mes, int flag)
                (flag == 1) ? SendWho::ALL_SAMEMAP :
                (flag == 2) ? SendWho::AREA :
                (flag == 3) ? SendWho::SELF :
-               SendWho::ALL_CLIENT);
+               SendWho::ALL_CLIENT, MIN_CLIENT_VERSION);
 }
 
 /*==========================================
@@ -2899,7 +2889,7 @@ void clif_resurrection(dumb_ptr<block_list> bl, int type)
     Buffer buf = create_fpacket<0x0148, 8>(fixed_148);
 
     clif_send(buf, bl,
-            type == 1 ? SendWho::AREA : SendWho::AREA_WOS);
+            type == 1 ? SendWho::AREA : SendWho::AREA_WOS, MIN_CLIENT_VERSION);
 }
 
 /*==========================================
@@ -2986,7 +2976,7 @@ int clif_party_info(PartyPair p, Session *s)
     if (sd != nullptr)
     {
         Buffer buf = create_vpacket<0x00fb, 28, 46>(head_fb, repeat_fb);
-        clif_send(buf, sd, SendWho::PARTY);
+        clif_send(buf, sd, SendWho::PARTY, MIN_CLIENT_VERSION);
     }
     return 0;
 }
@@ -3063,7 +3053,7 @@ void clif_party_option(PartyPair p, dumb_ptr<map_session_data> sd, int flag)
     if (flag == 0)
     {
         Buffer buf = create_fpacket<0x0101, 6>(fixed_101);
-        clif_send(buf, sd, SendWho::PARTY);
+        clif_send(buf, sd, SendWho::PARTY, MIN_CLIENT_VERSION);
     }
     else
     {
@@ -3097,7 +3087,7 @@ void clif_party_leaved(PartyPair p, dumb_ptr<map_session_data> sd,
         if (sd != nullptr)
         {
             Buffer buf = create_fpacket<0x0105, 31>(fixed_105);
-            clif_send(buf, sd, SendWho::PARTY);
+            clif_send(buf, sd, SendWho::PARTY, MIN_CLIENT_VERSION);
         }
     }
     else if (sd != nullptr)
@@ -3127,7 +3117,7 @@ void clif_party_message(PartyPair p, AccountId account_id, XString mes)
         Packet_Head<0x0109> head_109;
         head_109.account_id = account_id;
         Buffer buf = create_vpacket<0x0109, 8, 1>(head_109, mes);
-        clif_send(buf, sd, SendWho::PARTY);
+        clif_send(buf, sd, SendWho::PARTY, MIN_CLIENT_VERSION);
     }
 }
 
@@ -3144,7 +3134,7 @@ int clif_party_xy(PartyPair , dumb_ptr<map_session_data> sd)
     fixed_107.x = sd->bl_x;
     fixed_107.y = sd->bl_y;
     Buffer buf = create_fpacket<0x0107, 10>(fixed_107);
-    clif_send(buf, sd, SendWho::PARTY_SAMEMAP_WOS);
+    clif_send(buf, sd, SendWho::PARTY_SAMEMAP_WOS, MIN_CLIENT_VERSION);
     return 0;
 }
 
@@ -3162,7 +3152,7 @@ int clif_party_hp(PartyPair , dumb_ptr<map_session_data> sd)
     fixed_106.max_hp =
         (sd->status.max_hp > 0x7fff) ? 0x7fff : sd->status.max_hp;
     Buffer buf = create_fpacket<0x0106, 10>(fixed_106);
-    clif_send(buf, sd, SendWho::PARTY_AREA_WOS);
+    clif_send(buf, sd, SendWho::PARTY_AREA_WOS, MIN_CLIENT_VERSION);
     return 0;
 }
 
@@ -3199,7 +3189,7 @@ void clif_emotion(dumb_ptr<block_list> bl, int type)
     fixed_c0.block_id = bl->bl_id;
     fixed_c0.type = type;
     Buffer buf = create_fpacket<0x00c0, 7>(fixed_c0);
-    clif_send(buf, bl, SendWho::AREA);
+    clif_send(buf, bl, SendWho::AREA, MIN_CLIENT_VERSION);
 }
 
 void clif_emotion_towards(dumb_ptr<block_list> bl,
@@ -3232,7 +3222,7 @@ void clif_sitting(Session *, dumb_ptr<map_session_data> sd)
     fixed_8a.src_id = sd->bl_id;
     fixed_8a.damage_type = DamageType::SIT;
     Buffer buf = create_fpacket<0x008a, 29>(fixed_8a);
-    clif_send(buf, sd, SendWho::AREA);
+    clif_send(buf, sd, SendWho::AREA, MIN_CLIENT_VERSION);
 }
 
 static
@@ -3256,7 +3246,7 @@ void clif_sitnpc_towards(dumb_ptr<map_session_data> sd, dumb_ptr<npc_data> nd, D
 
     Buffer buf;
     clif_sitnpc_sub(buf, nd, dmg);
-    clif_send(buf, sd, SendWho::SELF);
+    clif_send(buf, sd, SendWho::SELF, MIN_CLIENT_VERSION);
 }
 
 void clif_sitnpc(dumb_ptr<npc_data> nd, DamageType dmg)
@@ -3265,7 +3255,7 @@ void clif_sitnpc(dumb_ptr<npc_data> nd, DamageType dmg)
 
     Buffer buf;
     clif_sitnpc_sub(buf, nd, dmg);
-    clif_send(buf, nd, SendWho::AREA);
+    clif_send(buf, nd, SendWho::AREA, MIN_CLIENT_VERSION);
 }
 
 static
@@ -3302,7 +3292,7 @@ void clif_setnpcdirection_towards(dumb_ptr<map_session_data> sd, dumb_ptr<npc_da
 
     Buffer buf;
     clif_setnpcdirection_sub(buf, nd, direction);
-    clif_send(buf, sd, SendWho::SELF);
+    clif_send(buf, sd, SendWho::SELF, MIN_CLIENT_VERSION);
 }
 
 void clif_setnpcdirection(dumb_ptr<npc_data> nd, DIR direction)
@@ -3311,7 +3301,7 @@ void clif_setnpcdirection(dumb_ptr<npc_data> nd, DIR direction)
 
     Buffer buf;
     clif_setnpcdirection_sub(buf, nd, direction);
-    clif_send(buf, nd, SendWho::AREA);
+    clif_send(buf, nd, SendWho::AREA, MIN_CLIENT_VERSION);
 }
 
 /*==========================================
@@ -3370,9 +3360,9 @@ int clif_specialeffect(dumb_ptr<block_list> bl, int type, int flag)
         }
     }
     else if (flag == 1)
-        clif_send(buf, bl, SendWho::SELF);
+        clif_send(buf, bl, SendWho::SELF, MIN_CLIENT_VERSION);
     else if (!flag)
-        clif_send(buf, bl, SendWho::AREA);
+        clif_send(buf, bl, SendWho::AREA, MIN_CLIENT_VERSION);
 
     return 0;
 
@@ -3792,7 +3782,7 @@ RecvResult clif_parse_GlobalMessage(Session *s, dumb_ptr<map_session_data> sd)
         XString repeat_8d = mbuf;
         Buffer sendbuf = create_vpacket<0x008d, 8, 1>(head_8d, repeat_8d);
 
-        clif_send(sendbuf, sd, SendWho::AREA_CHAT_WOC);
+        clif_send(sendbuf, sd, SendWho::AREA_CHAT_WOC, MIN_CLIENT_VERSION);
     }
 
     /* Send the message back to the speaker. */
@@ -3813,7 +3803,7 @@ void clif_message(dumb_ptr<block_list> bl, XString msg)
     head_8d.block_id = bl->bl_id;
     Buffer buf = create_vpacket<0x008d, 8, 1>(head_8d, msg);
 
-    clif_send(buf, bl, SendWho::AREA);
+    clif_send(buf, bl, SendWho::AREA, MIN_CLIENT_VERSION);
 }
 
 /*==========================================
@@ -3857,7 +3847,7 @@ RecvResult clif_parse_ChangeDir(Session *s, dumb_ptr<map_session_data> sd)
     fixed_9c.client_dir = client_dir;
     Buffer buf = create_fpacket<0x009c, 9>(fixed_9c);
 
-    clif_send(buf, sd, SendWho::AREA_WOS);
+    clif_send(buf, sd, SendWho::AREA_WOS, MIN_CLIENT_VERSION);
 
     return rv;
 }
@@ -3882,7 +3872,7 @@ RecvResult clif_parse_Emotion(Session *s, dumb_ptr<map_session_data> sd)
         fixed_c0.block_id = sd->bl_id;
         fixed_c0.type = emote;
         Buffer buf = create_fpacket<0x00c0, 7>(fixed_c0);
-        clif_send(buf, sd, SendWho::AREA);
+        clif_send(buf, sd, SendWho::AREA, MIN_CLIENT_VERSION);
     }
     else
         clif_skill_fail(sd, SkillID::ONE, 0, 1);
@@ -3953,7 +3943,7 @@ RecvResult clif_parse_ActionRequest(Session *s, dumb_ptr<map_session_data> sd)
             fixed_8a.src_id = sd->bl_id;
             fixed_8a.damage_type = DamageType::STAND;
             Buffer buf = create_fpacket<0x008a, 29>(fixed_8a);
-            clif_send(buf, sd, SendWho::AREA);
+            clif_send(buf, sd, SendWho::AREA, MIN_CLIENT_VERSION);
             break;
     }
 

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -930,6 +930,8 @@ int clif_spawnpc(dumb_ptr<map_session_data> sd)
 
     clif_send(buf, sd, SendWho::AREA_WOS);
 
+    clif_pvpstatus(sd);
+
     if (sd->bl_m->flag.get(MapFlag::SNOW))
         clif_specialeffect(sd, 162, 1);
     if (sd->bl_m->flag.get(MapFlag::FOG))
@@ -2046,6 +2048,19 @@ int clif_misceffect(dumb_ptr<block_list> bl, int type)
     clif_send(buf, bl, SendWho::AREA);
 
     return 0;
+}
+
+void clif_pvpstatus(dumb_ptr<map_session_data> sd)
+{
+    nullpo_retv(sd);
+
+    Packet_Fixed<0x019a> fixed_19a;
+    fixed_19a.block_id = sd->bl_id;
+    fixed_19a.rank = sd->state.pvp_rank;
+    fixed_19a.channel = sd->state.pvpchannel;
+    Buffer buf = create_fpacket<0x019a, 14>(fixed_19a);
+
+    clif_send(buf, sd, SendWho::AREA);
 }
 
 /*==========================================

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -2050,6 +2050,20 @@ int clif_misceffect(dumb_ptr<block_list> bl, int type)
     return 0;
 }
 
+void clif_map_pvp(dumb_ptr<map_session_data> sd)
+{
+    nullpo_retv(sd);
+
+    if (sd->client_version < 3)
+        return;
+
+    Packet_Fixed<0x0199> fixed_199;
+    fixed_199.status = sd->bl_m->flag.get(MapFlag::PVP)? 1: 0;
+    Buffer buf = create_fpacket<0x0199, 4>(fixed_199);
+
+    clif_send(buf, sd, SendWho::SELF);
+}
+
 void clif_pvpstatus(dumb_ptr<map_session_data> sd)
 {
     nullpo_retv(sd);
@@ -3469,6 +3483,8 @@ RecvResult clif_parse_LoadEndAck(Session *s, dumb_ptr<map_session_data> sd)
 
     map_addblock(sd);     // ブロック登録
     clif_spawnpc(sd);          // spawn
+
+    clif_map_pvp(sd); // send map pvp status
 
     // weight max , now
     clif_updatestatus(sd, SP::MAXWEIGHT);

--- a/src/map/clif.hpp
+++ b/src/map/clif.hpp
@@ -72,6 +72,7 @@ void clif_scriptclose(dumb_ptr<map_session_data>, BlockId); //self
 void clif_scriptmenu(dumb_ptr<map_session_data>, BlockId, XString);  //self
 void clif_scriptinput(dumb_ptr<map_session_data>, BlockId); //self
 void clif_scriptinputstr(dumb_ptr<map_session_data> sd, BlockId npcid);  // self
+void clif_map_pvp(dumb_ptr<map_session_data>); // self
 
 int clif_additem(dumb_ptr<map_session_data>, IOff0, int, PickupFail);   //self
 void clif_delitem(dumb_ptr<map_session_data>, IOff0, int);    //self

--- a/src/map/clif.hpp
+++ b/src/map/clif.hpp
@@ -92,6 +92,7 @@ int clif_statusupack(dumb_ptr<map_session_data>, SP, int, int);   // self
 int clif_equipitemack(dumb_ptr<map_session_data>, IOff0, EPOS, int);  // self
 int clif_unequipitemack(dumb_ptr<map_session_data>, IOff0, EPOS, int);    // self
 int clif_misceffect(dumb_ptr<block_list>, int);    // area
+void clif_pvpstatus(dumb_ptr<map_session_data>); // area
 int clif_changeoption(dumb_ptr<block_list>);   // area
 int clif_useitemack(dumb_ptr<map_session_data>, IOff0, int, int);    // self
 

--- a/src/map/magic-stmt.cpp
+++ b/src/map/magic-stmt.cpp
@@ -771,10 +771,12 @@ int op_injure(dumb_ptr<env_t> env, Slice<val_t> args)
     int target_hp = battle_get_hp(target);
     int mdef = battle_get_mdef(target);
 
-    if (target->bl_type == BL::PC
-        && !target->bl_m->flag.get(MapFlag::PVP)
-        && (caster->bl_type == BL::PC)
-        && ((caster->is_player()->state.pvpchannel > 1) && (target->is_player()->state.pvpchannel != caster->is_player()->state.pvpchannel)))
+    if (target->bl_type == BL::PC                       // target is player
+        && !target->bl_m->flag.get(MapFlag::PVP)        // there is no pvpon flag
+        && (caster->bl_type == BL::PC)                  // caster is player
+        && ((target->is_player()->state.pvpchannel == 0)
+            || ((caster->is_player()->state.pvpchannel > 0)
+                && (target->is_player()->state.pvpchannel != caster->is_player()->state.pvpchannel))))
         return 0;               /* Cannot damage other players outside of pvp */
 
     if (target != caster)

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -143,6 +143,7 @@ struct map_session_data : block_list, SessionData
         unsigned shroud_disappears_on_talk:1;
         unsigned seen_motd:1;
         unsigned pvpchannel;
+        unsigned pvp_rank;
     } state;
     struct
     {

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -3313,6 +3313,11 @@ int pc_damage(dumb_ptr<block_list> src, dumb_ptr<map_session_data> sd,
         };
         npc_event_doall_l(stringish<ScriptLabel>("OnPCKilledEvent"_s), sd->bl_id, arg);
         npc_event_doall_l(stringish<ScriptLabel>("OnPCKillEvent"_s), src->bl_id, arg);
+
+        sd->state.pvp_rank = 0;
+        src->is_player()->state.pvp_rank++;
+        clif_pvpstatus(sd);
+        clif_pvpstatus(src->is_player());
     }
     npc_event_doall_l(stringish<ScriptLabel>("OnPCDieEvent"_s), sd->bl_id, nullptr);
 

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -944,7 +944,7 @@ int pc_calcstatus(dumb_ptr<map_session_data> sd, int first)
     b_mdef = sd->mdef;
     b_mdef2 = sd->mdef2;
     b_base_atk = sd->base_atk;
-    if (!pc_isdead(sd) && sd->state.pvpchannel == 1)
+    if (sd->state.pvpchannel == 1)
         b_pvpchannel = sd->state.pvpchannel;
 
     sd->max_weight = max_weight_base_0 + sd->status.attrs[ATTR::STR] * 300;

--- a/src/mmo/version.hpp
+++ b/src/mmo/version.hpp
@@ -36,6 +36,9 @@ namespace tmwa
 #define TMWA_SERVER_MAP        0x08
 
 // increase the min version when the protocol is incompatible with old m+ versions
+// 1 = latest mana, old manaplus, bots
+// 2 = manaplus 1.5.5.9 and above
+// 3 = manaplus 1.5.5.23 and above
 #define MIN_CLIENT_VERSION 1
 
 // TODO now that I generate the protocol, split 'flags' out of the struct

--- a/tools/protocol.py
+++ b/tools/protocol.py
@@ -4280,6 +4280,21 @@ def build_context():
     )
     # 0x0199 define='SMSG_PVP_MAP_MODE',
     # 0x019a define='SMSG_PVP_SET',
+    map_user.s(0x019a, 'being pvp status',
+        define='SMSG_BEING_SELFEFFECT',
+        fixed=[
+            at(0, u16, 'packet id'),
+            at(2, block_id, 'block id'),
+            at(6, u32, 'rank'),
+            at(10, u32, 'channel'),
+        ],
+        fixed_size=14,
+        pre=[NOTHING],
+        post=[PRETTY],
+        desc='''
+            Send the pvp status
+        ''',
+    )
     map_user.s(0x019b, 'being effect',
         define='SMSG_BEING_SELFEFFECT',
         fixed=[

--- a/tools/protocol.py
+++ b/tools/protocol.py
@@ -4278,10 +4278,21 @@ def build_context():
             Being adds/removes a persistent status effect.
         ''',
     )
-    # 0x0199 define='SMSG_PVP_MAP_MODE',
-    # 0x019a define='SMSG_PVP_SET',
+    map_user.s(0x0199, 'map pvp status',
+        define='SMSG_PVP_MAP_MODE',
+        fixed=[
+            at(0, u16, 'packet id'),
+            at(2, u16, 'status'),
+        ],
+        fixed_size=4,
+        pre=[NOTHING],
+        post=[PRETTY],
+        desc='''
+            Send the map pvp status
+        ''',
+    )
     map_user.s(0x019a, 'being pvp status',
-        define='SMSG_BEING_SELFEFFECT',
+        define='SMSG_PVP_SET',
         fixed=[
             at(0, u16, 'packet id'),
             at(2, block_id, 'block id'),


### PR DESCRIPTION
* Send the pvp rank (which is just a kill-streak for now) to the client
* Send the pvp channel to the client [so that it can draw in red the players in the same channel as you](https://github.com/ManaPlus/ManaPlus/pull/13)

to-do in this PR:
* ~~send player hp while in pvp (except if the player has a shroud)~~ **nevermind.** manaplus has no decent way to send player hp (there is only a packet to send player hp for parties)


to-do in the future:
* remove or find a use for legacy `pvp_rank` and `pvp_point` which are not global rank but per-map rank and resets on warp and does not work with the channels. We could recycle it for the channel system and remove the legacy pvp rank system (unused).
* spawn players with pvp as mobs (manaplus allows mobs to have clothes)

- - - 
closes https://github.com/themanaworld/tmwa/issues/102