### PR TITLE
deprecate mob visible in favor of mob move

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -955,15 +955,9 @@ int clif_walkok(dumb_ptr<map_session_data> sd)
 {
     nullpo_retz(sd);
 
-    Session *s = sd->sess;
-    Packet_Fixed<0x0087> fixed_87;
-    fixed_87.tick = gettick();
-    fixed_87.pos2.x0 = sd->bl_x;
-    fixed_87.pos2.y0 = sd->bl_y;
-    fixed_87.pos2.x1 = sd->to_x;
-    fixed_87.pos2.y1 = sd->to_y;
-    fixed_87.zero = 0;
-    send_fpacket<0x0087, 12>(s, fixed_87);
+    // this is not required by manaplus since manaplus assumes that walking
+    // always work and that the server will otherwise send a correction notice
+    //clif_send_entity_move(sd, sd);
 
     return 0;
 }

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -3051,7 +3051,7 @@ int clif_party_hp(PartyPair , dumb_ptr<map_session_data> sd)
 /*==========================================
  * 攻撃するために移動が必要
  *------------------------------------------
- */
+ *
 int clif_movetoattack(dumb_ptr<map_session_data> sd, dumb_ptr<block_list> bl)
 {
     nullpo_retz(sd);
@@ -3067,7 +3067,7 @@ int clif_movetoattack(dumb_ptr<map_session_data> sd, dumb_ptr<block_list> bl)
     fixed_139.range = sd->attackrange;
     send_fpacket<0x0139, 16>(s, fixed_139);
     return 0;
-}
+}*/
 
 /*==========================================
  * エモーション

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -774,30 +774,29 @@ void clif_set007b(dumb_ptr<map_session_data> sd, Buffer& buf)
 static
 void clif_entity_move(dumb_ptr<block_list> bl, Buffer& buf)
 {
-    dumb_ptr<mob_data> md = bl->is_mob(); // FIXME: make this packet compatible with npcs when npcs become mobs
-    nullpo_retv(md);
-    int max_hp = md->stats[mob_stat::MAX_HP];
-    int hp = md->hp;
-
     Packet_Fixed<0x007b> fixed_7b;
-    fixed_7b.block_id = md->bl_id;
-    fixed_7b.speed = battle_get_speed(md);
-    fixed_7b.opt1 = md->opt1;
-    fixed_7b.opt2 = md->opt2;
-    fixed_7b.option = md->option;
-    fixed_7b.mob_class = md->mob_class;
+    fixed_7b.block_id = bl->bl_id;
+    fixed_7b.speed = battle_get_speed(bl);
     fixed_7b.tick = gettick();
+    fixed_7b.pos2.x0 = bl->bl_x;
+    fixed_7b.pos2.y0 = bl->bl_y;
+    fixed_7b.pos2.x1 = bl->to_x;
+    fixed_7b.pos2.y1 = bl->to_y;
 
-    fixed_7b.pos2.x0 = md->bl_x;
-    fixed_7b.pos2.y0 = md->bl_y;
-    fixed_7b.pos2.x1 = md->to_x;
-    fixed_7b.pos2.y1 = md->to_y;
-
-    fixed_7b.gloves_or_part_of_hp = static_cast<short>(hp & 0xffff);
-    fixed_7b.part_of_guild_id_or_part_of_hp = static_cast<short>(hp >> 16);
-    fixed_7b.part_of_guild_id_or_part_of_max_hp = static_cast<short>(max_hp & 0xffff);
-    fixed_7b.guild_emblem_or_part_of_max_hp = static_cast<short>(max_hp >> 16);
-    fixed_7b.karma_or_attack_range = battle_get_range(md);
+    dumb_ptr<mob_data> md = bl->is_mob();
+    if (md)
+    {
+        int max_hp = md->stats[mob_stat::MAX_HP];
+        int hp = md->hp;
+        fixed_7b.opt1 = md->opt1;
+        fixed_7b.option = md->option;
+        fixed_7b.mob_class = md->mob_class;
+        fixed_7b.gloves_or_part_of_hp = static_cast<short>(hp & 0xffff);
+        fixed_7b.part_of_guild_id_or_part_of_hp = static_cast<short>(hp >> 16);
+        fixed_7b.part_of_guild_id_or_part_of_max_hp = static_cast<short>(max_hp & 0xffff);
+        fixed_7b.guild_emblem_or_part_of_max_hp = static_cast<short>(max_hp >> 16);
+        fixed_7b.karma_or_attack_range = battle_get_range(md);
+    }
 
     buf = create_fpacket<0x007b, 60>(fixed_7b);
 }
@@ -2426,20 +2425,20 @@ int clif_damage(dumb_ptr<block_list> src, dumb_ptr<block_list> dst,
 static
 void clif_entity_move_path(dumb_ptr<block_list> bl, Buffer& buf)
 {
-    dumb_ptr<mob_data> md = bl->is_mob(); // FIXME: make this packet compatible with npcs when npcs become mobs
-    nullpo_retv(md);
+    nullpo_retv(bl);
 
     Packet_Head<0x0225> head_225;
     std::vector<Packet_Repeat<0x0225>> repeat_225;
-    head_225.magic_packet_length = md->walkpath.path_len + 14;
-    head_225.id = md->bl_id;
-    head_225.speed = battle_get_speed(md);
-    head_225.x_position = md->bl_x;
-    head_225.y_position = md->bl_y;
-    for (int i = 0; i < md->walkpath.path_len; i++)
+    head_225.id = bl->bl_id;
+    head_225.speed = battle_get_speed(bl);
+    head_225.x_position = bl->bl_x;
+    head_225.y_position = bl->bl_y;
+
+    head_225.magic_packet_length = bl->walkpath.path_len + 14;
+    for (int i = 0; i < bl->walkpath.path_len; i++)
     {
         Packet_Repeat<0x0225> move_225;
-        move_225.move = md->walkpath.path[i];
+        move_225.move = bl->walkpath.path[i];
         repeat_225.push_back(move_225);
     }
 

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -134,6 +134,9 @@ static
 void clif_sitnpc_sub(Buffer& buf, dumb_ptr<npc_data> nd, DamageType dmg);
 
 static
+void clif_mob007b(dumb_ptr<mob_data> md, Buffer& buf);
+
+static
 void clif_delete(Session *s)
 {
     assert (s != char_session);
@@ -765,35 +768,13 @@ void clif_set007b(dumb_ptr<map_session_data> sd, Buffer& buf)
 }
 
 /*==========================================
- * MOB表示1
+ * DEPRECATED
  *------------------------------------------
  */
 static
 void clif_mob0078(dumb_ptr<mob_data> md, Buffer& buf)
 {
-    nullpo_retv(md);
-    int max_hp = md->stats[mob_stat::MAX_HP];
-    int hp = md->hp;
-
-    Packet_Fixed<0x0078> fixed_78;
-    fixed_78.block_id = md->bl_id;
-    fixed_78.speed = battle_get_speed(md);
-    fixed_78.opt1 = md->opt1;
-    fixed_78.opt2 = md->opt2;
-    fixed_78.option = md->option;
-    fixed_78.species = md->mob_class;
-    // snip: stuff do do with disguise as a PC
-    fixed_78.pos.x = md->bl_x;
-    fixed_78.pos.y = md->bl_y;
-    fixed_78.pos.dir = md->dir;
-
-    fixed_78.gloves_or_part_of_hp = static_cast<short>(hp & 0xffff);
-    fixed_78.part_of_guild_id_or_part_of_hp = static_cast<short>(hp >> 16);
-    fixed_78.part_of_guild_id_or_part_of_max_hp = static_cast<short>(max_hp & 0xffff);
-    fixed_78.guild_emblem_or_part_of_max_hp = static_cast<short>(max_hp >> 16);
-    fixed_78.karma_or_attack_range = battle_get_range(md);
-
-    buf = create_fpacket<0x0078, 54>(fixed_78);
+    clif_mob007b(md, buf);
 }
 
 /*==========================================

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -69,13 +69,20 @@ constexpr std::chrono::seconds DEFAULT_AUTOSAVE_INTERVAL = 1_min;
 
 extern map_local undefined_gat;
 
+struct walkpath_data
+{
+    unsigned char path_len, path_pos, path_half;
+    Array<DIR, MAX_WALKPATH> path;
+};
+
 struct block_list
 {
     dumb_ptr<block_list> bl_next, bl_prev;
     BlockId bl_id;
     Borrowed<map_local> bl_m = borrow(undefined_gat);
-    short bl_x, bl_y;
+    short bl_x, bl_y, to_x, to_y;
     BL bl_type;
+    struct walkpath_data walkpath;
 
     // This deletes the copy-ctor also
     // TODO give proper ctors.
@@ -98,11 +105,6 @@ public:
     dumb_ptr<magic::invocation> is_spell();
 };
 
-struct walkpath_data
-{
-    unsigned char path_len, path_pos, path_half;
-    Array<DIR, MAX_WALKPATH> path;
-};
 struct status_change
 {
     Timer timer;
@@ -173,13 +175,11 @@ struct map_session_data : block_list, SessionData
     int weight, max_weight;
     MapName mapname_;
     Session *sess; // use this, you idiots!
-    short to_x, to_y;
     interval_t speed;
     Opt1 opt1;
     Opt2 opt2;
     Opt3 opt3;
     DIR dir, head_dir;
-    struct walkpath_data walkpath;
     Timer walktimer;
     BlockId npc_id, areanpc_id, npc_shopid;
     // this is important
@@ -435,11 +435,9 @@ struct mob_data : block_list
         unsigned special_mob_ai:3;
     } state;
     Timer timer;
-    short to_x, to_y;
     int hp;
     BlockId target_id, attacked_id;
     ATK target_lv;
-    struct walkpath_data walkpath;
     tick_t next_walktime;
     tick_t attackabletime;
     tick_t last_deadtime, last_spawntime, last_thinktime;

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -2635,9 +2635,8 @@ void pc_attack_timer(TimerData *, tick_t tick, BlockId id)
         if (dist <= range && !battle_check_range(sd, bl, range))
         {
             if (pc_can_reach(sd, bl->bl_x, bl->bl_y) && sd->canmove_tick < tick)
-                // TMW client doesn't support this
-                //pc_walktoxy(sd,bl->bl_x,bl->bl_y);
-                clif_movetoattack(sd, bl);
+                pc_walktoxy(sd,bl->bl_x,bl->bl_y);
+                //clif_movetoattack(sd, bl);
             sd->attackabletime = tick + (sd->aspd * 2);
         }
         else


### PR DESCRIPTION
Manaplus handles `SMSG_BEING_VISIBLE` and `SMSG_BEING_MOVE` the exact same way so there is no reason to send being visible for mobs because being move has the added benefit of having the to_x and to_y so I made it send being move when the mob is moving instead of being visible
