### PR TITLE
Don't segfault when inserting remote maps into DB.

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1237,7 +1237,8 @@ int map_setipport(MapName name, IP4Address ip, int port)
             mdos->gat = nullptr;
             mdos->ip = ip;
             mdos->port = port;
-            maps_db.put(mdos->name_, std::move(mdos));
+            MapName mName = mdos->name_;
+            maps_db.put(mName, std::move(mdos));
         }
     }
     OMATCH_END ();


### PR DESCRIPTION
This allows multiple map servers per char server to split the world between them. 

The only feature tested is that switching between map servers occurs without crashing.