### PR TITLE
simplify global npcs

### DIFF
--- a/src/ast/npc.cpp
+++ b/src/ast/npc.cpp
@@ -401,7 +401,7 @@ namespace npc
 
             ast::script::ScriptOptions opt;
             opt.implicit_start = true;
-            opt.no_start = true;
+            opt.default_label = "OnCall"_s;
             rv.body = TRY(ast::script::parse_script_body(lr, opt));
             return Ok(std::move(rv));
         }

--- a/src/ast/npc.cpp
+++ b/src/ast/npc.cpp
@@ -306,10 +306,10 @@ namespace npc
     static
     Result<ScriptNone> parse_script_none_head(io::LineSpan span, std::vector<Spanned<std::vector<Spanned<RString>>>>& bits)
     {
-        //  ScriptNone:         -|script|script name|32767{code}
-        if (bits.size() != 4)
+        //  ScriptNone:         -|script|script name{code}
+        if (bits.size() != 3)
         {
-            return Err(span.error_str("expect 4 |component|s"_s));
+            return Err(span.error_str("expect 3 |component|s"_s));
         }
         assert(bits[0].data.size() == 1);
         assert(bits[0].data[0].data == "-"_s);
@@ -319,16 +319,10 @@ namespace npc
         {
             return Err(bits[2].span.error_str("in |component 3| expect 1 ,component,s"_s));
         }
-        assert(bits[3].data[0].data == "32767"_s);
-        if (bits[3].data.size() != 1)
-        {
-            return Err(bits[3].span.error_str("in |component 4| should be just 32767"_s));
-        }
 
         ScriptNone script_none;
         script_none.key1_span = bits[0].data[0].span;
         TRY_EXTRACT(bits[2].data[0], script_none.name);
-        script_none.key4_span = bits[3].data[0].span;
         // also expect '{' and parse real script (in caller)
         return Ok(std::move(script_none));
     }

--- a/src/ast/npc_test.cpp
+++ b/src/ast/npc_test.cpp
@@ -423,11 +423,11 @@ namespace npc
         {
             //        1         2         3
             //23456789012345678901234567890123456789
-            "-|script|#config|32767{end;}"_s,
+            "-|script|#config{end;}"_s,
             //                    123456
-            "-|script|#config|32767\n{end;}\n"_s,
+            "-|script|#config\n{end;}\n"_s,
             //                      1234567
-            "-|script|#config|32767\n \n {end;} "_s,
+            "-|script|#config\n \n {end;} "_s,
         };
         for (auto input : inputs)
         {
@@ -435,7 +435,7 @@ namespace npc
             auto res = TRY_UNWRAP(parse_top(lr), FAIL());
             EXPECT_TRUE(res.get_success().is_some());
             auto top = TRY_UNWRAP(std::move(res.get_success()), FAIL());
-            EXPECT_SPAN(top.span, 1,1, 1,22);
+            EXPECT_SPAN(top.span, 1,1, 1,16);
             auto script = top.get_if<Script>();
             EXPECT_TRUE(script);
             auto p = script->get_if<ScriptNone>();
@@ -446,10 +446,9 @@ namespace npc
                 EXPECT_SPAN(script->key_span, 1,3, 1,8);
                 EXPECT_SPAN(p->name.span, 1,10, 1,16);
                 EXPECT_EQ(p->name.data, stringish<NpcName>("#config"_s));
-                EXPECT_SPAN(p->key4_span, 1,18, 1,22);
                 if (input.endswith('}'))
                 {
-                    EXPECT_SPAN(script->body.span, 1,23, 1,28);
+                    EXPECT_SPAN(script->body.span, 1,17, 1,22);
                 }
                 else if (input.endswith('\n'))
                 {


### PR DESCRIPTION
Npcs that are global (no map) now do not require `|32767`

## requires https://github.com/themanaworld/tmwa-server-data/pull/400