### PR TITLE
do not count hidden players

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -183,7 +183,7 @@ int map_addblock(dumb_ptr<block_list> bl)
         if (bl->bl_next)
             bl->bl_next->bl_prev = bl;
         m->blocks.ref(x / BLOCK_SIZE, y / BLOCK_SIZE).normal = bl;
-        if (bl->bl_type == BL::PC)
+        if (bl->bl_type == BL::PC && !bool(bl->is_player()->status.option & Opt0::HIDE))
             m->users++;
     }
 


### PR DESCRIPTION
closes https://github.com/themanaworld/tmwa/issues/117

Let's say someone is doing  boss run and a GM does `@hugo` and enters the room before the next round start. This would cause `getmapusers` to also count the GM so it would make it harder for players as the boss room would spawn more mobs since it would expect one more player. (I tested with Celestia)

`getareausers` does not suffer from this problem because it checks `Opt0::HIDE` but `getmapusers` just grabs `m->users`