### PR TITLE
Warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ sudo: false
 ## Commands before installing
 before_install:
   - if [ $(git rev-list --count HEAD ^master) -gt 50 ] ; then exit 1; fi
-  - export CC=${REAL_CC} CXX=${REAL_CXX}
+  - export CC="${REAL_CC} ${REAL_EXTRA}" CXX="${REAL_CXX} ${REAL_EXTRA}"
 
 install:
   - make --version
@@ -31,29 +31,45 @@ install:
   - cd build
   - git init
   - ../configure --build=x86_64-linux-gnu --dev CPPFLAGS=-DQUIET `! [[ $CXX =~ clang* ]] || echo --disable-abi` $EXTRA_CONFIGURE_ARGS
+  - sed -n '/One Makefile/q;p' Makefile
 
 ## Main test script
 script:
   - make -R -k -j2
-  - make -R -k -j2 test TESTER='valgrind --error-exitcode=1 --track-fds=yes'
-
-## Do something after the main test script
-after_success:
+  # Use - instead of :- to allow forcing an empty one
+  - make -R -k -j2 test TESTER="${FORCE_TESTER-${DEFAULT_TESTER}}"
   - make -R -k -j2 format
   - git --git-dir=../.git --work-tree=.. diff --exit-code
   - make -R -k -j2 dist bindist
 
 ### The rest of the file creates a build matrix
-
+env:
+  global:
+    - DEFAULT_TESTER='valgrind --error-exitcode=1 --track-fds=yes'
 matrix:
   fast-finish: true
   include:
+    - compiler: clang
+      env: REAL_CC=clang-3.5     REAL_CXX=clang++-3.5
+      addons:
+        apt:
+          sources:
+          - llvm-toolchain-precise-3.5
+          # needed for libstdc++ headers
+          - ubuntu-toolchain-r-test
+          packages:
+          - clang-3.5
+          - libstdc++6-4.6-dbg
+          - libgtest-dev
+          - valgrind
+          - gdb
     - compiler: clang
       env: REAL_CC=clang-3.6     REAL_CXX=clang++-3.6
       addons:
         apt:
           sources:
           - llvm-toolchain-precise-3.6
+          # needed for libstdc++ headers
           - ubuntu-toolchain-r-test
           packages:
           - clang-3.6
@@ -67,10 +83,35 @@ matrix:
         apt:
           sources:
           - llvm-toolchain-precise-3.7
+          # needed for libstdc++ headers
           - ubuntu-toolchain-r-test
           packages:
           - clang-3.7
           - libstdc++6-4.6-dbg
+          - libgtest-dev
+          - valgrind
+          - gdb
+    - compiler: gcc
+      env: REAL_CC=gcc-4.7     REAL_CXX=g++-4.7
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - g++-4.7
+          - libstdc++6-4.7-dbg
+          - libgtest-dev
+          - valgrind
+          - gdb
+    - compiler: gcc
+      env: REAL_CC=gcc-4.8     REAL_CXX=g++-4.8
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - g++-4.8
+          - libstdc++6-4.8-dbg
           - libgtest-dev
           - valgrind
           - gdb
@@ -98,6 +139,35 @@ matrix:
           - libgtest-dev
           - valgrind
           - gdb
+    # Can't use valgrind and asan at the same time.
+    # Should probably fix the test leaks though.
+    - compiler: gcc
+      env: REAL_CC=gcc-5     REAL_CXX=g++-5  REAL_EXTRA=-fsanitize=address  FORCE_TESTER='' ASAN_OPTIONS=detect_leaks=0
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - g++-5
+          - libstdc++6-5-dbg
+          - libgtest-dev
+          # - valgrind
+          - gdb
+    # LTO is buggy.
+    - compiler: gcc
+      env: REAL_CC=gcc-5     REAL_CXX=g++-5  REAL_EXTRA=-flto
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - g++-5
+          - libstdc++6-5-dbg
+          - libgtest-dev
+          - valgrind
+          - gdb
+  allow_failures:
+    - env: REAL_CC=gcc-5     REAL_CXX=g++-5  REAL_EXTRA=-flto
 
 # everything that was pushed to stable was already on 'master', except
 # the version change and some doc changes.

--- a/src/diagnostics.hpp
+++ b/src/diagnostics.hpp
@@ -1,7 +1,7 @@
 #pragma once
 //    diagnostics.hpp - List of useful warnings and macros to control them.
 //
-//    Copyright © 2013-2014 Ben Longbons <b.r.longbons@gmail.com>
+//    Copyright © 2013-2015 Ben Longbons <b.r.longbons@gmail.com>
 //
 //    This file is part of The Mana World (Athena server)
 //
@@ -20,6 +20,7 @@
 
 // just mention "fwd.hpp" to make formatter happy
 
+// Last updated for: GCC 5.2
 
 namespace tmwa
 {
@@ -29,19 +30,24 @@ namespace tmwa
 // * because token dispatching, it can't be #define HAS_XXX (GCC >= yyy)
 // * gcc 4.6 is required for function scope pragmas
 // * when upgrading compiler, diff 'gcc --help=warnings'
+//   (Unfortunately this is not good about warnings specific to a single
+//   language in some version, which may change, and often lies)
 // * clang-specific warning support is incomplete
 
 // List of warnings that require arguments,
 // and thus cannot reliably be activated:
-//  gcc 4.6:
-//      -Wlarger-than=<1024>
-//      -Wnormalized=<id|nfc|nfd>
-//      -Wsuggest-attribute=<noreturn,const,pure,format>
-//  gcc 4.7:
-//      -Wstack-usage=<8192>
 //  ???:
 //      -Wstrict-aliasing=<1>
 //      -Wstrict-overflow=<1>
+//  gcc 4.6:
+//      -Wlarger-than=<1024>
+//      -Wnormalized=<none|id|nfc|nfd>
+//      -Wsuggest-attribute=<noreturn,const,pure,format>
+//  gcc 4.7:
+//      -Wstack-usage=<8192>
+//  gcc 5:
+//      -Wabi=<8> (but no argument works)
+//      -Warray-bounds=<???> (but no argument works)
 
 #ifdef __GNUC__
 # ifdef __clang__
@@ -61,7 +67,7 @@ namespace tmwa
 #endif
 
 #define DIAG_E(tag) DO_DIAG_IF(HAS_DIAG_##tag)(error, DIAG_##tag)
-#define DIAG_W(tag) DO_DIAG_IF(HAS_DIAG_##tag)(warning, DIAG_##tag)
+#define DIAG_W(tag) DO_DIAG_IF(HAS_DIAG_##tag)(error, DIAG_##tag)
 #define DIAG_I(tag) DO_DIAG_IF(HAS_DIAG_##tag)(ignored, DIAG_##tag)
 #define DIAG_X(tag) DO_DIAG_IF(HAS_DIAG_##tag)(ignored, DIAG_##tag)
 
@@ -81,8 +87,10 @@ namespace tmwa
 #define DIAG_POP() PRAGMA(GCC diagnostic pop)
 
 
-/// Warn about things that will change when compiling
+/// (with no argument) Warn about things that will change when compiling
 /// with an ABI-compliant compiler
+/// (with an argmuent) Warn about things that change between the current
+/// -fabi-version and the specified version
 // see note about -fabi-version=6 in the makefile
 #define DIAG_abi "-Wabi"
 #if 1
@@ -132,8 +140,17 @@ namespace tmwa
 # define HAS_DIAG_attributes 0
 #endif
 
+/// Warn about boolean expression compared with an
+/// integer value different from true/false
+#define DIAG_bool_compare "-Wbool-compare"
+#if GCC >= 500
+# define HAS_DIAG_bool_compare 1
+#else
+# define HAS_DIAG_bool_compare 0
+#endif
+
 /// Warn when a built-in preprocessor macro is
-// undefined or redefined
+/// undefined or redefined
 #define DIAG_builtin_macro_redefined "-Wbuiltin-macro-redefined"
 #if 1
 # define HAS_DIAG_builtin_macro_redefined 1
@@ -156,6 +173,15 @@ namespace tmwa
 #else
 # define HAS_DIAG_cxx0x_compat 0
 # define HAS_DIAG_cxx11_compat 0
+#endif
+
+/// Warn about C++ constructs whose meaning differs
+/// between ISO C++ 2011 and ISO C++ 2014
+#define DIAG_cxx14_compat "-Wc++14-compat"
+#if GCC >= 500
+# define HAS_DIAG_cxx14_compat 1
+#else
+# define HAS_DIAG_cxx14_compat 0
 #endif
 
 // I care about whether my code compiles with the standard as implemented
@@ -189,6 +215,15 @@ namespace tmwa
 # define HAS_DIAG_char_subscripts 1
 #else
 # define HAS_DIAG_char_subscripts 0
+#endif
+
+/// Warn about memory access errors found by Pointer
+/// Bounds Checker
+#define DIAG_chkp "-Wchkp"
+#if GCC >= 500
+# define HAS_DIAG_chkp 1
+#else
+# define HAS_DIAG_chkp 0
 #endif
 
 /// Warn about variables that might be changed by
@@ -452,6 +487,14 @@ namespace tmwa
 # define HAS_DIAG_format_security 0
 #endif
 
+/// Warn about sign differences with format functions
+#define DIAG_format_signedness "-Wformat-signedness"
+#if GCC >= 500
+# define HAS_DIAG_format_signedness 1
+#else
+# define HAS_DIAG_format_signedness 0
+#endif
+
 /// Warn about strftime formats yielding 2-digit years
 #define DIAG_format_y2k "-Wformat-y2k"
 #if 1
@@ -571,6 +614,15 @@ namespace tmwa
 # define HAS_DIAG_literal_suffix 1
 #else
 # define HAS_DIAG_literal_suffix 0
+#endif
+
+/// Warn when logical not is used on the left hand
+/// side operand of a comparison
+#define DIAG_logical_not_parentheses "-Wlogical-not-parentheses"
+#if GCC >= 500
+# define HAS_DIAG_logical_not_parentheses 1
+#else
+# define HAS_DIAG_logical_not_parentheses 0
 #endif
 
 /// Warn when a logical operator is suspiciously
@@ -760,6 +812,15 @@ namespace tmwa
 # define HAS_DIAG_null_conversion 0
 #endif
 
+/// Warn about some C++ One Definition Rule
+/// violations during link time optimization
+#define DIAG_odr "-Wodr"
+#if GCC >= 500
+# define HAS_DIAG_odr 1
+#else
+# define HAS_DIAG_odr 0
+#endif
+
 /// Warn if a C-style cast is used in a program
 #define DIAG_old_style_cast "-Wold-style-cast"
 #if 1
@@ -922,6 +983,31 @@ namespace tmwa
 # define HAS_DIAG_shadow 0
 #endif
 
+/// Warn if a local declaration hides an instance
+/// variable
+#define DIAG_shadow_ivar "-Wshadow-ivar"
+#if GCC >= 500
+# define HAS_DIAG_shadow_ivar 1
+#else
+# define HAS_DIAG_shadow_ivar 0
+#endif
+
+/// Warn if shift count is negative
+#define DIAG_shift_count_negative "-Wshift-count-negative"
+#if GCC >= 500
+# define HAS_DIAG_shift_count_negative 1
+#else
+# define HAS_DIAG_shift_count_negative 0
+#endif
+
+/// Warn if shift count >= width of type
+#define DIAG_shift_count_overflow "-Wshift-count-overflow"
+#if GCC >= 500
+# define HAS_DIAG_shift_count_overflow 1
+#else
+# define HAS_DIAG_shift_count_overflow 0
+#endif
+
 /// Warn about signed-unsigned comparisons
 #define DIAG_sign_compare "-Wsign-compare"
 #if 1
@@ -939,7 +1025,26 @@ namespace tmwa
 # define HAS_DIAG_sign_promo 0
 #endif
 
-/// This switch lacks documentation
+/// Warn about missing sized deallocation functions
+#define DIAG_sized_deallocation "-Wsized-deallocation"
+#if GCC >= 500
+# define HAS_DIAG_sized_deallocation 1
+#else
+# define HAS_DIAG_sized_deallocation 0
+#endif
+
+/// Warn when sizeof is applied on a parameter
+/// declared as an array
+#define DIAG_sizeof_array_argument "-Wsizeof-array-argument"
+#if GCC >= 500
+# define HAS_DIAG_sizeof_array_argument 1
+#else
+# define HAS_DIAG_sizeof_array_argument 0
+#endif
+
+/// Warn about suspicious length parameters to
+/// certain string functions if the argument uses
+/// sizeof
 #define DIAG_sizeof_pointer_memaccess "-Wsizeof-pointer-memaccess"
 #if GCC >= 408
 # define HAS_DIAG_sizeof_pointer_memaccess 1
@@ -982,6 +1087,34 @@ namespace tmwa
 # define HAS_DIAG_strict_overflow 0
 #endif
 
+/// Warn about C++ virtual methods where adding final
+/// keyword would improve code quality
+#define DIAG_suggest_final_methods "-Wsuggest-final-methods"
+#if GCC >= 500
+# define HAS_DIAG_suggest_final_methods 1
+#else
+# define HAS_DIAG_suggest_final_methods 0
+#endif
+
+/// Warn about C++ polymorphic types where adding
+/// final keyword would improve code quality
+#define DIAG_suggest_final_types "-Wsuggest-final-types"
+#if GCC >= 500
+# define HAS_DIAG_suggest_final_types 1
+#else
+# define HAS_DIAG_suggest_final_types 0
+#endif
+
+/// Suggest that the override keyword be used when
+/// the declaration of a virtual function overrides
+/// another.
+#define DIAG_suggest_override "-Wsuggest-override"
+#if GCC >= 500
+# define HAS_DIAG_suggest_override 1
+#else
+# define HAS_DIAG_suggest_override 0
+#endif
+
 /// Warn about enumerated switches, with no default,
 /// missing a case
 #define DIAG_switch "-Wswitch"
@@ -989,6 +1122,15 @@ namespace tmwa
 # define HAS_DIAG_switch 1
 #else
 # define HAS_DIAG_switch 0
+#endif
+
+/// Warn about switches with boolean controlling
+/// expression
+#define DIAG_switch_bool "-Wswitch-bool"
+#if GCC >= 500
+# define HAS_DIAG_switch_bool 1
+#else
+# define HAS_DIAG_switch_bool 0
 #endif
 
 /// Warn about enumerated switches missing a

--- a/src/warnings.hpp
+++ b/src/warnings.hpp
@@ -4,7 +4,7 @@
 // The preceding sentence is a lie.
 //    warnings.hpp - Make the compiler do the hard work.
 //
-//    Copyright © 2013 Ben Longbons <b.r.longbons@gmail.com>
+//    Copyright © 2013-2015 Ben Longbons <b.r.longbons@gmail.com>
 //
 //    This file is part of The Mana World (Athena server)
 //
@@ -34,17 +34,20 @@ PRAGMA(GCC diagnostic warning "-Wunused");
 PRAGMA(GCC diagnostic warning "-Wformat");
 
 DIAG_E(abi);
-DIAG_W(abi_tag);
+DIAG_I(abi_tag);
 DIAG_E(address);
 DIAG_I(aggregate_return);
 DIAG_E(array_bounds);
 DIAG_E(attributes);
+DIAG_E(bool_compare);
 DIAG_E(builtin_macro_redefined);
 DIAG_I(cxx0x_compat);
+DIAG_W(cxx14_compat);
 DIAG_I(cxx1y_extensions);
 DIAG_E(cast_align);
 DIAG_E(cast_qual);
 DIAG_E(char_subscripts);
+DIAG_W(chkp);
 DIAG_E(clobbered);
 DIAG_E(comment);
 DIAG_E(conditionally_supported);
@@ -84,6 +87,7 @@ DIAG_I(format_security);
 DIAG_E(format_nonliteral);
 DIAG_E(format_security);
 #endif
+DIAG_X(format_signedness);
 DIAG_E(format_y2k);
 DIAG_I(format_zero_length);
 DIAG_E(free_nonheap_object);
@@ -98,6 +102,7 @@ DIAG_W(invalid_memory_model);
 DIAG_E(invalid_offsetof);
 DIAG_E(invalid_pch);
 DIAG_W(literal_suffix);
+DIAG_W(logical_not_parentheses);
 DIAG_W(logical_op);
 DIAG_I(long_long);
 DIAG_E(main);
@@ -112,7 +117,7 @@ DIAG_E(missing_field_initializers);
 #endif
 DIAG_E(missing_format_attribute);
 DIAG_E(missing_include_dirs);
-DIAG_W(missing_noreturn);
+DIAG_X(missing_noreturn);
 DIAG_E(missing_prototypes);
 #ifndef GTEST_HAS_PTHREAD // this is a hack
 DIAG_E(missing_variable_declarations);
@@ -127,6 +132,7 @@ DIAG_E(non_template_friend);
 DIAG_E(non_virtual_dtor);
 DIAG_E(nonnull);
 DIAG_E(null_conversion);
+DIAG_W(odr);
 DIAG_E(old_style_cast);
 DIAG_W(overflow);
 DIAG_E(openmp_simd);
@@ -145,14 +151,23 @@ DIAG_W(return_local_addr);
 DIAG_E(return_type);
 DIAG_E(sequence_point);
 DIAG_E(shadow);
+DIAG_E(shadow_ivar);
+DIAG_E(shift_count_negative);
+DIAG_E(shift_count_overflow);
 DIAG_X(sign_compare);
 DIAG_E(sign_promo);
+DIAG_W(sized_deallocation);
+DIAG_E(sizeof_array_argument);
 DIAG_W(sizeof_pointer_memaccess);
+DIAG_X(suggest_final_methods);
+DIAG_X(suggest_final_types);
+DIAG_X(suggest_override);
 DIAG_X(stack_protector);
 DIAG_E(strict_aliasing);
 DIAG_W(strict_null_sentinel);
 DIAG_X(strict_overflow);
 DIAG_I(switch);
+DIAG_I(switch_bool);
 DIAG_I(switch_default);
 DIAG_I(switch_enum);
 DIAG_W(sync_nand);


### PR DESCRIPTION
* Update warning list for GCC 5.
* Change `DIAG_W` to be fatal too. But both this and `DIAG_X` should be carefully looked at to see whether they currently, or in the future, could be changed to `DIAG_E` or must be `DIAG_I`.
* Make sure old-but-supported GCC versions are still tested in dev mode.
* Add asan and lto builds
* Fix tests not failing the build.
* Dump configure output.