### PR TITLE
implement SMSG_SCRIPT_MESSAGE

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -3886,6 +3886,26 @@ void clif_npc_send_title(Session *s, BlockId npcid, XString msg)
     send_buffer(s, buf);
 }
 
+void clif_server_message(dumb_ptr<map_session_data> sd, uint8_t type, XString msg)
+{
+    nullpo_retv(sd);
+
+    size_t msg_len = msg.size() + 8;
+    if (msg_len > 512)
+        return;
+
+    // for newer clients
+    Packet_Head<0x0229> head_229;
+    head_229.message_type = type;
+    Buffer buf = create_vpacket<0x0229, 5, 1>(head_229, msg);
+
+    // falback for older clients
+    Packet_Head<0x008d> head_8d;
+    Buffer altbuf = create_vpacket<0x008d, 8, 1>(head_8d, msg);
+
+    clif_send(buf, sd, SendWho::SELF, wrap<ClientVersion>(5), altbuf);
+}
+
 void clif_change_music(dumb_ptr<map_session_data> sd, XString music)
 {
     nullpo_retv(sd);

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -3906,6 +3906,20 @@ void clif_server_message(dumb_ptr<map_session_data> sd, uint8_t type, XString ms
     clif_send(buf, sd, SendWho::SELF, wrap<ClientVersion>(5), altbuf);
 }
 
+void clif_remote_command(dumb_ptr<map_session_data> sd, XString cmd)
+{
+    nullpo_retv(sd);
+
+    size_t msg_len = cmd.size() + 4;
+    if (msg_len > 512)
+        return;
+
+    Packet_Head<0x0230> head_230;
+    Buffer buf = create_vpacket<0x0230, 4, 1>(head_230, cmd);
+
+    clif_send(buf, sd, SendWho::SELF, wrap<ClientVersion>(6));
+}
+
 void clif_change_music(dumb_ptr<map_session_data> sd, XString music)
 {
     nullpo_retv(sd);

--- a/src/map/clif.hpp
+++ b/src/map/clif.hpp
@@ -105,6 +105,7 @@ void clif_sitnpc_towards(dumb_ptr<map_session_data> sd, dumb_ptr<npc_data> nd, D
 void clif_setnpcdirection(dumb_ptr<npc_data> nd, DIR direction);
 void clif_setnpcdirection_towards(dumb_ptr<map_session_data> sd, dumb_ptr<npc_data> nd, DIR direction);
 void clif_npc_send_title(Session *s, BlockId npcid, XString msg);
+void clif_server_message(dumb_ptr<map_session_data>, uint8_t, XString msg);
 void clif_change_music(dumb_ptr<map_session_data> sd, XString music);
 void clif_npc_action(dumb_ptr<map_session_data>, BlockId, short, int, short, short);
 void clif_send_mask(dumb_ptr<map_session_data>, int);

--- a/src/map/clif.hpp
+++ b/src/map/clif.hpp
@@ -106,6 +106,7 @@ void clif_setnpcdirection(dumb_ptr<npc_data> nd, DIR direction);
 void clif_setnpcdirection_towards(dumb_ptr<map_session_data> sd, dumb_ptr<npc_data> nd, DIR direction);
 void clif_npc_send_title(Session *s, BlockId npcid, XString msg);
 void clif_server_message(dumb_ptr<map_session_data>, uint8_t, XString msg);
+void clif_remote_command(dumb_ptr<map_session_data>, XString);
 void clif_change_music(dumb_ptr<map_session_data> sd, XString music);
 void clif_npc_action(dumb_ptr<map_session_data>, BlockId, short, int, short, short);
 void clif_send_mask(dumb_ptr<map_session_data>, int);

--- a/src/map/script-fun.cpp
+++ b/src/map/script-fun.cpp
@@ -2950,6 +2950,28 @@ void builtin_title(ScriptState *st)
 }
 
 static
+void builtin_smsg(ScriptState *st)
+{
+    dumb_ptr<map_session_data> sd = script_rid2sd(st);
+    if (HARG(2))
+    {
+        CharName player = stringish<CharName>(ZString(conv_str(st, &AARG(2))));
+        sd = map_nick2sd(player);
+        if (sd == nullptr)
+            return;
+    }
+
+    int type = HARG(1) ? conv_num(st, &AARG(0)) : 0;
+    ZString msg = ZString(conv_str(st, (HARG(1) ? &AARG(1) : &AARG(0))));
+    if (sd == nullptr)
+        return;
+    if (type < 0 || type > 0xFF)
+        type = 0;
+
+    clif_server_message(sd, type, msg);
+}
+
+static
 void builtin_music(ScriptState *st)
 {
     dumb_ptr<map_session_data> sd = script_rid2sd(st);
@@ -3490,6 +3512,7 @@ BuiltinFunction builtin_functions[] =
     BUILTIN(message, "Ps"_s, '\0'),
     BUILTIN(npctalk, "ss?"_s, '\0'),
     BUILTIN(title, "s"_s, '\0'),
+    BUILTIN(smsg, "e??"_s, '\0'),
     BUILTIN(music, "s"_s, '\0'),
     BUILTIN(mapmask, "i?"_s, '\0'),
     BUILTIN(getmask, ""_s, 'i'),

--- a/src/map/script-fun.cpp
+++ b/src/map/script-fun.cpp
@@ -2957,8 +2957,6 @@ void builtin_smsg(ScriptState *st)
     {
         CharName player = stringish<CharName>(ZString(conv_str(st, &AARG(2))));
         sd = map_nick2sd(player);
-        if (sd == nullptr)
-            return;
     }
 
     int type = HARG(1) ? conv_num(st, &AARG(0)) : 0;
@@ -2969,6 +2967,22 @@ void builtin_smsg(ScriptState *st)
         type = 0;
 
     clif_server_message(sd, type, msg);
+}
+
+static
+void builtin_remotecmd(ScriptState *st)
+{
+    dumb_ptr<map_session_data> sd = script_rid2sd(st);
+    if (HARG(1))
+    {
+        CharName player = stringish<CharName>(ZString(conv_str(st, &AARG(1))));
+        sd = map_nick2sd(player);
+    }
+
+    ZString msg = ZString(conv_str(st, &AARG(0)));
+    if (sd == nullptr)
+        return;
+    clif_remote_command(sd, msg);
 }
 
 static
@@ -3513,6 +3527,7 @@ BuiltinFunction builtin_functions[] =
     BUILTIN(npctalk, "ss?"_s, '\0'),
     BUILTIN(title, "s"_s, '\0'),
     BUILTIN(smsg, "e??"_s, '\0'),
+    BUILTIN(remotecmd, "s?"_s, '\0'),
     BUILTIN(music, "s"_s, '\0'),
     BUILTIN(mapmask, "i?"_s, '\0'),
     BUILTIN(getmask, ""_s, 'i'),

--- a/tools/protocol.py
+++ b/tools/protocol.py
@@ -4761,6 +4761,24 @@ def build_context():
             Change npc title
         ''',
     )
+    map_user.s(0x0229, 'script message',
+        define='SMSG_SCRIPT_MESSAGE',
+        head=[
+            at(0, u16, 'packet id'),
+            at(2, u16, 'packet length'),
+            at(4, u8, 'message type'),
+        ],
+        head_size=5,
+        repeat=[
+            at(0, u8, 'c'),
+        ],
+        repeat_size=1,
+        pre=[NOTHING],
+        post=[PRETTY],
+        desc='''
+            Send server message
+        ''',
+    )
 
     # TOC_LOGINCHAR
     # login char

--- a/tools/protocol.py
+++ b/tools/protocol.py
@@ -4779,6 +4779,23 @@ def build_context():
             Send server message
         ''',
     )
+    map_user.s(0x0230, 'remote client command',
+        define='SMSG_PLAYER_CLIENT_COMMAND',
+        head=[
+            at(0, u16, 'packet id'),
+            at(2, u16, 'packet length'),
+        ],
+        head_size=4,
+        repeat=[
+            at(0, u8, 'c'),
+        ],
+        repeat_size=1,
+        pre=[NOTHING],
+        post=[PRETTY],
+        desc='''
+            Execute a client command remotely
+        ''',
+    )
 
     # TOC_LOGINCHAR
     # login char


### PR DESCRIPTION
### types for SMSG_SCRIPT_MESSAGE:
The type allows ManaPlus to know what the message is about, without having to guess

|type|meaning|default behaviour|
|:--:|:------|:----------------|
|0|debug information|log in debug tab|
|1|GM message (spam filter, etc)|log in General tab, highlight tab, play a sound|
|2|warning|log in debug tab, highlight tab|
|3|success|log in debug tab, highlight tab|
|4|failure|log in debug tab, highlight tab|
|5|error|log in debug tab, highlight tab|
|6|TMWA legal notice|log in debug tab|
|7|MOTD|log in debug tab|
|8|scheduled message|log in General tab, highlight tab, play a sound|
|9|event (candor, etc)|log in General tab, highlight tab, play a sound|

Default behaviour for all other types: log in debug tab, highlight tab

For all types, the player should be able to configure the destination tab, tab highlight, sound, text color