### PR TITLE
send hp 0 in pc_readparam when PC is dead

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -3435,6 +3435,8 @@ int pc_readparam(dumb_ptr<block_list> bl, SP type)
             val = sd ? pc_nextjobexp(sd) : 0;
             break;
         case SP::HP:
+            if (sd && pc_isdead(sd))
+                break; // val = 0
             val = battle_get_hp(bl);
             break;
         case SP::MAXHP:


### PR DESCRIPTION
Right now, players can `#inma` while dead (or use any other spell). It's being abused in Candor and such