### PR TITLE
WIP: fix npc overwritting bug

### DIFF
--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -3610,6 +3610,9 @@ ATCE atcommand_mapinfo(Session *s, dumb_ptr<map_session_data> sd,
             for (int i = 0; i < m_id->npc_num;)
             {
                 nd = m_id->npc[i];
+                if (nd == nullptr)
+                    continue;
+
                 switch (nd->dir)
                 {
                     case DIR::S:

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1012,16 +1012,23 @@ dumb_ptr<block_list> map_id2bl(BlockId id)
 int map_addnpc(Borrowed<map_local> m, dumb_ptr<npc_data> nd)
 {
     int i;
+    bool reuse_npc = false;
+
     for (i = 0; i < m->npc_num && i < MAX_NPC_PER_MAP; i++)
+    {
         if (m->npc[i] == nullptr)
+        {
+            reuse_npc = true;
             break;
+        }
+    }
     if (i == MAX_NPC_PER_MAP)
     {
         if (battle_config.error_log)
             PRINTF("too many NPCs in one map %s\n"_fmt, m->name_);
         return -1;
     }
-    if (i == m->npc_num)
+    if (reuse_npc == true || i == m->npc_num)
     {
         m->npc_num++;
     }

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -675,6 +675,9 @@ int npc_touch_areanpc(dumb_ptr<map_session_data> sd, Borrowed<map_local> m, int 
 
     for (i = 0; i < m->npc_num; i++)
     {
+        if (m->npc[i] == nullptr)
+            continue;
+
         if (m->npc[i]->flag & 1)
             continue;
 
@@ -697,7 +700,7 @@ int npc_touch_areanpc(dumb_ptr<map_session_data> sd, Borrowed<map_local> m, int 
             && y < m->npc[i]->bl_y - ys / 2 + ys)
             break;
     }
-    if (i == m->npc_num)
+    if (i == m->npc_num || m->npc[i] == nullptr)
     {
         return 1;
     }


### PR DESCRIPTION
# DO NOT MERGE YET
when any map exceeds 512 npcs it crashes the server. each puppet increases the counter.. I'm trying to recycle npcs